### PR TITLE
Bump version (v0.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v0.0.2](https://github.com/NubeIO/module-core-loraraw/tree/v0.0.2) (2023-12-10)
+
+- Remove ROS dependencies
+- Prerequisites:
+    - ROS >= 0.3.0
+
 ## [v0.0.1](https://github.com/NubeIO/module-core-loraraw/tree/v0.0.1) (2023-10-08)
 
 - First initial release


### PR DESCRIPTION
### Summary

- Remove ROS dependencies
- Prerequisites:
    - ROS >= 0.3.0