### PR TITLE
Fix: device's droplet creation

### DIFF
--- a/pkg/router.go
+++ b/pkg/router.go
@@ -89,7 +89,7 @@ func CreateDevice(m *nmodule.Module, r *router.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	v := r.PathParams[nargs.WithPoints]
+	v := r.QueryParams.Get(nargs.WithPoints)
 	dev, err := (*m).(*Module).addDevice(device, v == "true")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Parent ticket: #15

To resolve confusion between `query_params` and `path_params`. For example:

- API endpoint: `/api/devices/:uuid`
- API call: `/api/devices/dev_a0fbc0ed?with_points=true`

In that example:

- path_params: `uuid = dev_a0fbc0ed`
- query_params: `with_points = true`