### PR TITLE
Shift responsibility of updating and creating points to decoder

### DIFF
--- a/decoder/base.go
+++ b/decoder/base.go
@@ -9,6 +9,13 @@ import (
 
 var grpcMarshaller nmodule.Marshaller
 
+const (
+	SensorField = "sensor"
+	IDField     = "id"
+	RssiField   = "rssi"
+	SnrField    = "snr"
+)
+
 type CommonValues struct {
 	Sensor string  `json:"sensor"`
 	ID     string  `json:"id"`
@@ -18,6 +25,13 @@ type CommonValues struct {
 
 func InitGrpcMarshaller(marshaller nmodule.Marshaller) {
 	grpcMarshaller = marshaller
+}
+
+func GetCommonValueNames() []string {
+	return []string{
+		RssiField,
+		SnrField,
+	}
 }
 
 func DecodePayload(data string, devDesc *LoRaDeviceDescription, device *model.Device) error {

--- a/decoder/base.go
+++ b/decoder/base.go
@@ -1,11 +1,13 @@
-// Package decoder contains all device specific payload decoding and checks
 package decoder
 
 import (
+	"errors"
+	"github.com/NubeIO/lib-module-go/nmodule"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
 	"strconv"
 )
 
-const Voltage = "voltage"
+var grpcMarshaller nmodule.Marshaller
 
 type CommonValues struct {
 	Sensor string  `json:"sensor"`
@@ -14,16 +16,16 @@ type CommonValues struct {
 	Snr    float32 `json:"snr"`
 }
 
-func DecodePayload(data string, devDesc *LoRaDeviceDescription) (*CommonValues, interface{}) {
+func InitGrpcMarshaller(marshaller nmodule.Marshaller) {
+	grpcMarshaller = marshaller
+}
+
+func DecodePayload(data string, devDesc *LoRaDeviceDescription, device *model.Device) error {
 	if !devDesc.CheckLength(data) {
-		return nil, nil
+		return errors.New("invalid payload")
 	}
-	cmn, payload := devDesc.Decode(data, devDesc)
-	if cmn == nil {
-		return nil, nil
-	}
-	decodeCommonValues(cmn, data, devDesc.Model)
-	return cmn, payload
+	err := devDesc.Decode(data, devDesc, device)
+	return err
 }
 
 func ValidPayload(data string) bool {

--- a/decoder/devices_and_points.go
+++ b/decoder/devices_and_points.go
@@ -8,21 +8,21 @@ import (
 )
 
 type LoRaDeviceDescription struct {
-	DeviceName      string
-	Model           string
-	SensorCode      string
-	CheckLength     func(data string) bool
-	Decode          func(data string, devDesc *LoRaDeviceDescription, device *model.Device) error
-	GetPointsStruct func() interface{}
+	DeviceName    string
+	Model         string
+	SensorCode    string
+	CheckLength   func(data string) bool
+	Decode        func(data string, devDesc *LoRaDeviceDescription, device *model.Device) error
+	GetPointNames func() []string
 }
 
 var NilLoRaDeviceDescription = LoRaDeviceDescription{
-	DeviceName:      "",
-	Model:           "",
-	SensorCode:      "",
-	CheckLength:     NilLoRaDeviceDescriptionCheckLength,
-	Decode:          NilLoRaDeviceDescriptionDecode,
-	GetPointsStruct: NilLoRaDeviceDescriptionGetPointsStruct,
+	DeviceName:    "",
+	Model:         "",
+	SensorCode:    "",
+	CheckLength:   NilLoRaDeviceDescriptionCheckLength,
+	Decode:        NilLoRaDeviceDescriptionDecode,
+	GetPointNames: NilLoRaDeviceDescriptionGetPointsStruct,
 }
 
 func NilLoRaDeviceDescriptionCheckLength(data string) bool {
@@ -33,52 +33,52 @@ func NilLoRaDeviceDescriptionDecode(data string, devDesc *LoRaDeviceDescription,
 	return errors.New("nil decode function called")
 }
 
-func NilLoRaDeviceDescriptionGetPointsStruct() interface{} {
-	return struct{}{}
+func NilLoRaDeviceDescriptionGetPointsStruct() []string {
+	return []string{}
 }
 
 var LoRaDeviceDescriptions = [...]LoRaDeviceDescription{
 	{
-		DeviceName:      "MicroEdge",
-		Model:           schema.DeviceModelMicroEdgeV1,
-		CheckLength:     CheckPayloadLengthME,
-		Decode:          DecodeME,
-		GetPointsStruct: GetPointsStructME,
+		DeviceName:    "MicroEdge",
+		Model:         schema.DeviceModelMicroEdgeV1,
+		CheckLength:   CheckPayloadLengthME,
+		Decode:        DecodeME,
+		GetPointNames: GetMePointNames,
 	},
 	{
-		DeviceName:      "MicroEdge",
-		Model:           schema.DeviceModelMicroEdgeV2,
-		CheckLength:     CheckPayloadLengthME,
-		Decode:          DecodeME,
-		GetPointsStruct: GetPointsStructME,
+		DeviceName:    "MicroEdge",
+		Model:         schema.DeviceModelMicroEdgeV2,
+		CheckLength:   CheckPayloadLengthME,
+		Decode:        DecodeME,
+		GetPointNames: GetMePointNames,
 	},
 	{
-		DeviceName:      "Droplet",
-		Model:           schema.DeviceModelTHLM,
-		CheckLength:     CheckPayloadLengthDroplet,
-		Decode:          DecodeDropletTHLM,
-		GetPointsStruct: GetPointsStructTHLM,
+		DeviceName:    "Droplet",
+		Model:         schema.DeviceModelTHLM,
+		CheckLength:   CheckPayloadLengthDroplet,
+		Decode:        DecodeDropletTHLM,
+		GetPointNames: GetTHLMPointNames,
 	},
 	{
-		DeviceName:      "Droplet",
-		Model:           schema.DeviceModelTHL,
-		CheckLength:     CheckPayloadLengthDroplet,
-		Decode:          DecodeDropletTHL,
-		GetPointsStruct: GetPointsStructTHL,
+		DeviceName:    "Droplet",
+		Model:         schema.DeviceModelTHL,
+		CheckLength:   CheckPayloadLengthDroplet,
+		Decode:        DecodeDropletTHL,
+		GetPointNames: GetTHLPointNames,
 	},
 	{
-		DeviceName:      "Droplet",
-		Model:           schema.DeviceModelTH,
-		CheckLength:     CheckPayloadLengthDroplet,
-		Decode:          DecodeDropletTH,
-		GetPointsStruct: GetPointsStructTH,
+		DeviceName:    "Droplet",
+		Model:         schema.DeviceModelTH,
+		CheckLength:   CheckPayloadLengthDroplet,
+		Decode:        DecodeDropletTH,
+		GetPointNames: GetTHPointNames,
 	},
 	{
-		DeviceName:      "ZipHydroTap",
-		Model:           schema.DeviceModelZiptHydroTap,
-		CheckLength:     CheckPayloadLengthZHT,
-		Decode:          DecodeZHT,
-		GetPointsStruct: GetPointsStructZHT,
+		DeviceName:    "ZipHydroTap",
+		Model:         schema.DeviceModelZiptHydroTap,
+		CheckLength:   CheckPayloadLengthZHT,
+		Decode:        DecodeZHT,
+		GetPointNames: GetZHTPointNames,
 	},
 }
 
@@ -91,6 +91,6 @@ func GetDeviceDescription(device *model.Device) *LoRaDeviceDescription {
 	return &NilLoRaDeviceDescription
 }
 
-func GetDevicePointsStruct(device *model.Device) interface{} {
-	return GetDeviceDescription(device).GetPointsStruct()
+func GetDevicePointNames(device *model.Device) []string {
+	return GetDeviceDescription(device).GetPointNames()
 }

--- a/decoder/devices_and_points.go
+++ b/decoder/devices_and_points.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"errors"
 	"github.com/NubeIO/module-core-loraraw/schema"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
 	"strings"
@@ -11,7 +12,7 @@ type LoRaDeviceDescription struct {
 	Model           string
 	SensorCode      string
 	CheckLength     func(data string) bool
-	Decode          func(data string, devDesc *LoRaDeviceDescription) (*CommonValues, interface{})
+	Decode          func(data string, devDesc *LoRaDeviceDescription, device *model.Device) error
 	GetPointsStruct func() interface{}
 }
 
@@ -28,8 +29,8 @@ func NilLoRaDeviceDescriptionCheckLength(data string) bool {
 	return false
 }
 
-func NilLoRaDeviceDescriptionDecode(data string, devDesc *LoRaDeviceDescription) (*CommonValues, interface{}) {
-	return &CommonValues{}, struct{}{}
+func NilLoRaDeviceDescriptionDecode(data string, devDesc *LoRaDeviceDescription, device *model.Device) error {
+	return errors.New("nil decode function called")
 }
 
 func NilLoRaDeviceDescriptionGetPointsStruct() interface{} {

--- a/decoder/droplet.go
+++ b/decoder/droplet.go
@@ -62,13 +62,15 @@ func DecodeDropletTH(data string, devDesc *LoRaDeviceDescription, device *model.
 	}
 
 	temperature := dropletTemp(data)
-	_ = updateDevicePoint("temperature", temperature, device)
 	pressure := dropletPressure(data)
-	_ = updateDevicePoint("pressure", pressure, device)
 	humidity := dropletHumidity(data)
-	_ = updateDevicePoint("humidity", float64(humidity), device)
 	voltage := dropletVoltage(data)
+
+	_ = updateDevicePoint("temperature", temperature, device)
+	_ = updateDevicePoint("pressure", pressure, device)
+	_ = updateDevicePoint("humidity", float64(humidity), device)
 	_ = updateDevicePoint("voltage", voltage, device)
+
 	return nil
 }
 

--- a/decoder/droplet.go
+++ b/decoder/droplet.go
@@ -7,34 +7,34 @@ import (
 	"strconv"
 )
 
-type TDropletTH struct {
-	CommonValues
-	Voltage     float64 `json:"voltage"`
-	Temperature float64 `json:"temperature"`
-	Pressure    float64 `json:"pressure"`
-	Humidity    int     `json:"humidity"`
+const (
+	DropletVoltageField = "voltage"
+	TemperatureField    = "temperature"
+	PressureField       = "pressure"
+	HumidityField       = "humidity"
+	LightField          = "light"
+	MotionField         = "motion"
+)
+
+func GetTHPointNames() []string {
+	commonValueFields := GetCommonValueNames()
+	dropletTHFields := []string{
+		DropletVoltageField,
+		TemperatureField,
+		PressureField,
+		HumidityField,
+	}
+	return append(commonValueFields, dropletTHFields...)
 }
 
-type TDropletTHL struct {
-	TDropletTH
-	Light int `json:"light"`
+func GetTHLPointNames() []string {
+	dropletTHFields := GetTHPointNames()
+	return append(dropletTHFields, LightField)
 }
 
-type TDropletTHLM struct {
-	TDropletTHL
-	Motion bool `json:"motion"`
-}
-
-func GetPointsStructTH() interface{} {
-	return TDropletTH{}
-}
-
-func GetPointsStructTHL() interface{} {
-	return TDropletTHL{}
-}
-
-func GetPointsStructTHLM() interface{} {
-	return TDropletTHLM{}
+func GetTHLMPointNames() []string {
+	dropletTHLFields := GetTHLPointNames()
+	return append(dropletTHLFields, MotionField)
 }
 
 func CheckPayloadLengthDroplet(data string) bool {
@@ -51,12 +51,12 @@ func DecodeDropletTH(data string, devDesc *LoRaDeviceDescription, device *model.
 
 	updateDeviceFault(commonValues.ID, commonValues.Sensor, device.UUID, commonValues.Rssi)
 
-	err := updateDevicePoint("rssi", float64(commonValues.Rssi), device)
+	err := updateDevicePoint(RssiField, float64(commonValues.Rssi), device)
 	if err != nil {
 		return err
 	}
 
-	err = updateDevicePoint("snr", float64(commonValues.Snr), device)
+	err = updateDevicePoint(SnrField, float64(commonValues.Snr), device)
 	if err != nil {
 		return err
 	}
@@ -66,10 +66,10 @@ func DecodeDropletTH(data string, devDesc *LoRaDeviceDescription, device *model.
 	humidity := dropletHumidity(data)
 	voltage := dropletVoltage(data)
 
-	_ = updateDevicePoint("temperature", temperature, device)
-	_ = updateDevicePoint("pressure", pressure, device)
-	_ = updateDevicePoint("humidity", float64(humidity), device)
-	_ = updateDevicePoint("voltage", voltage, device)
+	_ = updateDevicePoint(TemperatureField, temperature, device)
+	_ = updateDevicePoint(PressureField, pressure, device)
+	_ = updateDevicePoint(HumidityField, float64(humidity), device)
+	_ = updateDevicePoint(DropletVoltageField, voltage, device)
 
 	return nil
 }
@@ -81,7 +81,7 @@ func DecodeDropletTHL(data string, devDesc *LoRaDeviceDescription, device *model
 	}
 
 	light := dropletLight(data)
-	_ = updateDevicePoint("light", float64(light), device)
+	_ = updateDevicePoint(LightField, float64(light), device)
 	return nil
 }
 
@@ -92,7 +92,7 @@ func DecodeDropletTHLM(data string, devDesc *LoRaDeviceDescription, device *mode
 	}
 
 	motion := dropletMotion(data)
-	_ = updateDevicePoint("motion", utils.BoolToFloat(motion), device)
+	_ = updateDevicePoint(MotionField, utils.BoolToFloat(motion), device)
 	return nil
 }
 

--- a/decoder/microedge.go
+++ b/decoder/microedge.go
@@ -9,17 +9,24 @@ import (
 	"strconv"
 )
 
-type TMicroEdge struct {
-	CommonValues
-	Voltage float64 `json:"voltage"`
-	Pulse   int     `json:"pulse"`
-	AI1     float64 `json:"ai_1"`
-	AI2     float64 `json:"ai_2"`
-	AI3     float64 `json:"ai_3"`
-}
+const (
+	MEVoltageField = "voltage"
+	PulseField     = "pulse"
+	AI1Field       = "ai_1"
+	AI2Field       = "ai_2"
+	AI3Field       = "ai_3"
+)
 
-func GetPointsStructME() interface{} {
-	return TMicroEdge{}
+func GetMePointNames() []string {
+	commonValueFields := GetCommonValueNames()
+	tMicroEdgeFields := []string{
+		MEVoltageField,
+		PulseField,
+		AI1Field,
+		AI2Field,
+		AI3Field,
+	}
+	return append(commonValueFields, tMicroEdgeFields...)
 }
 
 func CheckPayloadLengthME(data string) bool {
@@ -36,12 +43,12 @@ func DecodeME(data string, devDesc *LoRaDeviceDescription, device *model.Device)
 
 	updateDeviceFault(commonValues.ID, commonValues.Sensor, device.UUID, commonValues.Rssi)
 
-	err := updateDevicePoint("rssi", float64(commonValues.Rssi), device)
+	err := updateDevicePoint(RssiField, float64(commonValues.Rssi), device)
 	if err != nil {
 		return err
 	}
 
-	err = updateDevicePoint("snr", float64(commonValues.Snr), device)
+	err = updateDevicePoint(SnrField, float64(commonValues.Snr), device)
 	if err != nil {
 		return err
 	}
@@ -52,11 +59,11 @@ func DecodeME(data string, devDesc *LoRaDeviceDescription, device *model.Device)
 	a3 := ai3(data)
 	vol := voltage(data)
 
-	_ = updateDevicePoint("pulse", float64(p), device)
-	_ = updateDevicePoint("ai_1", a1, device)
-	_ = updateDevicePoint("ai_2", a2, device)
-	_ = updateDevicePoint("ai_3", a3, device)
-	_ = updateDevicePoint("voltage", vol, device)
+	_ = updateDevicePoint(PulseField, float64(p), device)
+	_ = updateDevicePoint(AI1Field, a1, device)
+	_ = updateDevicePoint(AI2Field, a2, device)
+	_ = updateDevicePoint(AI3Field, a3, device)
+	_ = updateDevicePoint(MEVoltageField, vol, device)
 
 	return nil
 }

--- a/decoder/microedge.go
+++ b/decoder/microedge.go
@@ -47,15 +47,17 @@ func DecodeME(data string, devDesc *LoRaDeviceDescription, device *model.Device)
 	}
 
 	p := pulse(data)
-	_ = updateDevicePoint("pulse", float64(p), device)
 	a1 := ai1(data)
-	_ = updateDevicePoint("ai_1", a1, device)
 	a2 := ai2(data)
-	_ = updateDevicePoint("ai_2", a2, device)
 	a3 := ai3(data)
-	_ = updateDevicePoint("ai_3", a3, device)
 	vol := voltage(data)
+
+	_ = updateDevicePoint("pulse", float64(p), device)
+	_ = updateDevicePoint("ai_1", a1, device)
+	_ = updateDevicePoint("ai_2", a2, device)
+	_ = updateDevicePoint("ai_3", a3, device)
 	_ = updateDevicePoint("voltage", vol, device)
+
 	return nil
 }
 

--- a/decoder/writer.go
+++ b/decoder/writer.go
@@ -11,13 +11,12 @@ import (
 	"strings"
 )
 
-func selectPointByIoNumber(ioNumber string, device *model.Device) *model.Point {
-	for _, pnt := range device.Points {
-		if pnt.IoNumber == ioNumber {
-			return pnt
-		}
-	}
-	return nil
+func updateDeviceFault(id, sensor, deviceUUID string, rssi int) {
+	log.Infof("sensor found. ID: %s, RSSI: %d, Type: %s", id, rssi, sensor)
+	_ = grpcMarshaller.UpdateDeviceFault(deviceUUID, &model.CommonFault{
+		InFault: false,
+		Message: "",
+	})
 }
 
 func updateDevicePoint(name string, value float64, device *model.Device) error {
@@ -38,9 +37,18 @@ func updateDevicePoint(name string, value float64, device *model.Device) error {
 	return nil
 }
 
+func selectPointByIoNumber(ioNumber string, device *model.Device) *model.Point {
+	for _, pnt := range device.Points {
+		if pnt.IoNumber == ioNumber {
+			return pnt
+		}
+	}
+	return nil
+}
+
 func addPointFromName(deviceBody *model.Device, name string) (*model.Point, error) {
 	point := new(model.Point)
-	setNewPointFields(deviceBody, point, name)
+	SetNewPointFields(deviceBody, point, name)
 	point.EnableWriteable = boolean.NewFalse()
 	pnt, err := savePoint(point)
 	return pnt, err
@@ -64,7 +72,7 @@ func addPoint(body *model.Point) (point *model.Point, err error) {
 	return point, nil
 }
 
-func setNewPointFields(deviceBody *model.Device, pointBody *model.Point, name string) {
+func SetNewPointFields(deviceBody *model.Device, pointBody *model.Point, name string) {
 	pointBody.Enable = boolean.NewTrue()
 	pointBody.DeviceUUID = deviceBody.UUID
 	pointBody.AddressUUID = deviceBody.AddressUUID
@@ -88,12 +96,4 @@ func updatePointValue(pnt *model.Point, value float64, deviceModel string) error
 		return err
 	}
 	return err
-}
-
-func updateDeviceFault(id, sensor, deviceUUID string, rssi int) {
-	log.Infof("sensor found. ID: %s, RSSI: %d, Type: %s", id, rssi, sensor)
-	_ = grpcMarshaller.UpdateDeviceFault(deviceUUID, &model.CommonFault{
-		InFault: false,
-		Message: "",
-	})
 }

--- a/decoder/writer.go
+++ b/decoder/writer.go
@@ -1,0 +1,99 @@
+package decoder
+
+import (
+	"github.com/NubeIO/lib-utils-go/boolean"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/datatype"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/dto"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"strings"
+)
+
+func selectPointByIoNumber(ioNumber string, device *model.Device) *model.Point {
+	for _, pnt := range device.Points {
+		if pnt.IoNumber == ioNumber {
+			return pnt
+		}
+	}
+	return nil
+}
+
+func updateDevicePoint(name string, value float64, device *model.Device) error {
+	pnt := selectPointByIoNumber(name, device)
+	if pnt == nil {
+		log.Debugf("failed to find point with address_uuid: %s and io_number: %s", *device.AddressUUID, name)
+		newPoint, err := addPointFromName(device, name)
+		if err != nil {
+			log.Errorf("failed to create point with address_uuid: %s and io_number: %s", *device.AddressUUID, name)
+			return err
+		}
+		pnt = newPoint
+	}
+	err := updatePointValue(pnt, value, device.Model)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func addPointFromName(deviceBody *model.Device, name string) (*model.Point, error) {
+	point := new(model.Point)
+	setNewPointFields(deviceBody, point, name)
+	point.EnableWriteable = boolean.NewFalse()
+	pnt, err := savePoint(point)
+	return pnt, err
+}
+
+func savePoint(point *model.Point) (*model.Point, error) {
+	point.EnableWriteable = boolean.NewFalse()
+	pnt, err := addPoint(point)
+	return pnt, err
+}
+
+func addPoint(body *model.Point) (point *model.Point, err error) {
+	body.ObjectType = "analog_input"
+	body.IoType = string(datatype.IOTypeRAW)
+	body.Name = strings.ToLower(body.Name)
+	body.EnableWriteable = boolean.NewFalse()
+	point, err = grpcMarshaller.CreatePoint(body) // TODO: in older one after creating there is an update operation
+	if err != nil {
+		return nil, err
+	}
+	return point, nil
+}
+
+func setNewPointFields(deviceBody *model.Device, pointBody *model.Point, name string) {
+	pointBody.Enable = boolean.NewTrue()
+	pointBody.DeviceUUID = deviceBody.UUID
+	pointBody.AddressUUID = deviceBody.AddressUUID
+	pointBody.IsOutput = boolean.NewFalse()
+	pointBody.Name = cases.Title(language.English).String(name)
+	pointBody.IoNumber = name
+	pointBody.ThingType = "point"
+	pointBody.WriteMode = datatype.ReadOnly
+}
+
+func updatePointValue(pnt *model.Point, value float64, deviceModel string) error {
+	if pnt.IoType != "" && pnt.IoType != string(datatype.IOTypeRAW) {
+		value = MicroEdgePointType(pnt.IoType, value, deviceModel)
+	}
+	pointWriter := dto.PointWriter{
+		OriginalValue: &value,
+	}
+	_, err := grpcMarshaller.PointWrite(pnt.UUID, &pointWriter)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	return err
+}
+
+func updateDeviceFault(id, sensor, deviceUUID string, rssi int) {
+	log.Infof("sensor found. ID: %s, RSSI: %d, Type: %s", id, rssi, sensor)
+	_ = grpcMarshaller.UpdateDeviceFault(deviceUUID, &model.CommonFault{
+		InFault: false,
+		Message: "",
+	})
+}

--- a/decoder/ziphydrotap.go
+++ b/decoder/ziphydrotap.go
@@ -308,87 +308,52 @@ func staticPayloadDecoder(data []byte) TZipHydrotapStatic {
 func writePayloadDecoder(data []byte, device *model.Device) error {
 	index := 1
 	time := int(binary.LittleEndian.Uint32(data[index : index+4]))
-	_ = updateDevicePoint("time", float64(time), device)
-
 	index += 4
 	dispB := int(data[index])
-	_ = updateDevicePoint("dispense_time_boiling", float64(dispB), device)
-
 	index += 1
 	dispC := int(data[index])
-	_ = updateDevicePoint("dispense_time_chilled", float64(dispC), device)
-
 	index += 1
 	dispS := int(data[index])
-	_ = updateDevicePoint("dispense_time_sparkling", float64(dispS), device)
-
 	index += 1
 	tempSpB := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("temperature_sp_boiling", float64(tempSpB), device)
-
 	index += 2
 	tempSpC := float32(int(data[index]))
-	_ = updateDevicePoint("temperature_sp_chilled", float64(tempSpC), device)
-
 	index += 1
 	tempSpS := float32(int(data[index]))
-	_ = updateDevicePoint("temperature_sp_sparkling", float64(tempSpS), device)
-
 	index += 1
 	sm := int(data[index])
-	_ = updateDevicePoint("sleep_mode_setting", float64(sm), device)
-
 	index += 1
 	filLyfLtrInt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("filter_info_life_litres_internal", float64(filLyfLtrInt), device)
-
 	index += 2
 	filLyfMnthInt := int(data[index])
-	_ = updateDevicePoint("filter_info_life_months_internal", float64(filLyfMnthInt), device)
-
 	index += 1
 	filLyfLtrExt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("filter_info_life_litres_external", float64(filLyfLtrExt), device)
-
 	index += 2
 	filLyfMnthExt := int(data[index])
-	_ = updateDevicePoint("filter_info_life_months_external", float64(filLyfMnthExt), device)
-
 	index += 1
 	sfTap := (data[index]>>2)&1 == 1
-	_ = updateDevicePoint("safety_allow_tap_changes", utils.BoolToFloat(sfTap), device)
-
 	sfL := (data[index]>>1)&1 == 1
-	_ = updateDevicePoint("safety_lock", utils.BoolToFloat(sfL), device)
-
 	sfHi := (data[index]>>0)&1 == 1
-	_ = updateDevicePoint("safety_hot_isolation", utils.BoolToFloat(sfHi), device)
-
 	index += 1
 	secUI16 := binary.LittleEndian.Uint16(data[index : index+2])
 	secEn := secUI16 >= 10000
-	_ = updateDevicePoint("security_enable", utils.BoolToFloat(secEn), device)
-
 	secPin := int(secUI16 % 10000)
-	_ = updateDevicePoint("security_pin", float64(secPin), device)
-
 	index += 2
+
 	var u16 uint16
 	for i := 0; i < ZipHTTimerLength; i++ {
 		u16 = binary.LittleEndian.Uint16(data[index : index+2])
 		timeStart := int(u16 % 10000)
-		_ = updateDevicePoint(fmt.Sprintf("time_start_%d", i), float64(timeStart), device)
 		enableStart := u16 >= 10000
-		_ = updateDevicePoint(fmt.Sprintf("enable_start_%d", i), utils.BoolToFloat(enableStart), device)
-
 		index += 2
 		u16 = binary.LittleEndian.Uint16(data[index : index+2])
 		timeStop := int(u16 % 10000)
-		_ = updateDevicePoint(fmt.Sprintf("time_stop_%d", i), float64(timeStop), device)
 		enableStop := u16 >= 10000
-		_ = updateDevicePoint(fmt.Sprintf("enable_stop_%d", i), utils.BoolToFloat(enableStop), device)
-
 		index += 2
+		_ = updateDevicePoint(fmt.Sprintf("time_start_%d", i), float64(timeStart), device)
+		_ = updateDevicePoint(fmt.Sprintf("enable_start_%d", i), utils.BoolToFloat(enableStart), device)
+		_ = updateDevicePoint(fmt.Sprintf("time_stop_%d", i), float64(timeStop), device)
+		_ = updateDevicePoint(fmt.Sprintf("enable_stop_%d", i), utils.BoolToFloat(enableStop), device)
 	}
 
 	filLyfLtrUV := 0
@@ -420,6 +385,25 @@ func writePayloadDecoder(data []byte, device *model.Device) error {
 		sparklFlushTime = int(binary.LittleEndian.Uint16(data[index : index+2]))
 		index += 2
 	}
+
+	_ = updateDevicePoint("time", float64(time), device)
+	_ = updateDevicePoint("dispense_time_boiling", float64(dispB), device)
+	_ = updateDevicePoint("dispense_time_chilled", float64(dispC), device)
+	_ = updateDevicePoint("dispense_time_sparkling", float64(dispS), device)
+	_ = updateDevicePoint("temperature_sp_boiling", float64(tempSpB), device)
+	_ = updateDevicePoint("temperature_sp_chilled", float64(tempSpC), device)
+	_ = updateDevicePoint("temperature_sp_sparkling", float64(tempSpS), device)
+	_ = updateDevicePoint("sleep_mode_setting", float64(sm), device)
+	_ = updateDevicePoint("filter_info_life_litres_internal", float64(filLyfLtrInt), device)
+	_ = updateDevicePoint("filter_info_life_months_internal", float64(filLyfMnthInt), device)
+	_ = updateDevicePoint("filter_info_life_litres_external", float64(filLyfLtrExt), device)
+	_ = updateDevicePoint("filter_info_life_months_external", float64(filLyfMnthExt), device)
+	_ = updateDevicePoint("safety_allow_tap_changes", utils.BoolToFloat(sfTap), device)
+	_ = updateDevicePoint("safety_lock", utils.BoolToFloat(sfL), device)
+	_ = updateDevicePoint("safety_hot_isolation", utils.BoolToFloat(sfHi), device)
+	_ = updateDevicePoint("security_enable", utils.BoolToFloat(secEn), device)
+	_ = updateDevicePoint("security_pin", float64(secPin), device)
+	// Pkt V2
 	_ = updateDevicePoint("filter_info_life_litres_uv", float64(filLyfLtrUV), device)
 	_ = updateDevicePoint("filter_info_life_months_uv", float64(filLyfMnthUV), device)
 	_ = updateDevicePoint("co2_life_grams", float64(cO2LyfGrams), device)
@@ -436,98 +420,51 @@ func writePayloadDecoder(data []byte, device *model.Device) error {
 func pollPayloadDecoder(data []byte, device *model.Device) error {
 	index := 1
 	rebooted := (data[index]>>5)&1 == 1
-	_ = updateDevicePoint("rebooted", utils.BoolToFloat(rebooted), device)
-
 	// sCov := (data[index]>>6)&1 == 1
 	// wCov := (data[index]>>7)&1 == 1
-
 	sms := int8((data[index]) & 0x3F)
-	_ = updateDevicePoint("sleep_mode_status", float64(sms), device)
-
 	index += 1
 	tempB := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("temperature_ntc_boiling", float64(tempB), device)
-
 	index += 2
 	tempC := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("temperature_ntc_chilled", float64(tempC), device)
-
 	index += 2
 	tempS := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("temperature_ntc_stream", float64(tempS), device)
-
 	index += 2
 	tempCond := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("temperature_ntc_condensor", float64(tempCond), device)
-
 	index += 2
 	f1 := data[index]
-	_ = updateDevicePoint("fault_1", float64(f1), device)
-
 	index += 1
 	f2 := data[index]
-	_ = updateDevicePoint("fault_2", float64(f2), device)
-
 	index += 1
 	f3 := data[index]
-	_ = updateDevicePoint("fault_3", float64(f3), device)
-
 	index += 1
 	f4 := data[index]
-	_ = updateDevicePoint("fault_4", float64(f4), device)
-
 	index += 1
 	kwh := float32(binary.LittleEndian.Uint32(data[index:index+4])) * 0.1
-	_ = updateDevicePoint("usage_energy_kwh", float64(kwh), device)
-
 	index += 4
 	dltDispB := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("usage_water_delta_dispenses_boiling", float64(dltDispB), device)
-
 	index += 2
 	dltDispC := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("usage_water_delta_dispenses_chilled", float64(dltDispC), device)
-
 	index += 2
 	dltDispS := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("usage_water_delta_dispenses_sparkling", float64(dltDispS), device)
-
 	index += 2
 	dltLtrB := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("usage_water_delta_litres_boiling", float64(dltLtrB), device)
-
 	index += 2
 	dltLtrC := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("usage_water_delta_litres_chilled", float64(dltLtrC), device)
-
 	index += 2
 	dltLtrS := float32(binary.LittleEndian.Uint16(data[index:index+2])) / 10
-	_ = updateDevicePoint("usage_water_delta_litres_sparkling", float64(dltLtrS), device)
-
 	index += 2
 	warningIndex := index
 	fltrWrnInt := (data[index]>>0)&1 == 1
-	_ = updateDevicePoint("filter_warning_internal", utils.BoolToFloat(fltrWrnInt), device)
-
 	fltrWrnExt := (data[index]>>1)&1 == 1
-	_ = updateDevicePoint("filter_warning_external", utils.BoolToFloat(fltrWrnExt), device)
-
 	index += 1
 	fltrNfoUseLtrInt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("filter_info_usage_litres_internal", float64(fltrNfoUseLtrInt), device)
-
 	index += 2
 	fltrNfoUseDayInt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("filter_info_usage_days_internal", float64(fltrNfoUseDayInt), device)
-
 	index += 2
 	fltrNfoUseLtrExt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("filter_info_usage_litres_external", float64(fltrNfoUseLtrExt), device)
-
 	index += 2
 	fltrNfoUseDayExt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	_ = updateDevicePoint("filter_info_usage_days_external", float64(fltrNfoUseDayExt), device)
-
 	index += 2
 
 	fltrNfoUseLtrUV := 0
@@ -549,6 +486,31 @@ func pollPayloadDecoder(data []byte, device *model.Device) error {
 		cO2UsgDays = int(data[index])
 		index += 1
 	}
+
+	_ = updateDevicePoint("rebooted", utils.BoolToFloat(rebooted), device)
+	_ = updateDevicePoint("sleep_mode_status", float64(sms), device)
+	_ = updateDevicePoint("temperature_ntc_boiling", float64(tempB), device)
+	_ = updateDevicePoint("temperature_ntc_chilled", float64(tempC), device)
+	_ = updateDevicePoint("temperature_ntc_stream", float64(tempS), device)
+	_ = updateDevicePoint("temperature_ntc_condensor", float64(tempCond), device)
+	_ = updateDevicePoint("fault_1", float64(f1), device)
+	_ = updateDevicePoint("fault_2", float64(f2), device)
+	_ = updateDevicePoint("fault_3", float64(f3), device)
+	_ = updateDevicePoint("fault_4", float64(f4), device)
+	_ = updateDevicePoint("usage_energy_kwh", float64(kwh), device)
+	_ = updateDevicePoint("usage_water_delta_dispenses_boiling", float64(dltDispB), device)
+	_ = updateDevicePoint("usage_water_delta_dispenses_chilled", float64(dltDispC), device)
+	_ = updateDevicePoint("usage_water_delta_dispenses_sparkling", float64(dltDispS), device)
+	_ = updateDevicePoint("usage_water_delta_litres_boiling", float64(dltLtrB), device)
+	_ = updateDevicePoint("usage_water_delta_litres_chilled", float64(dltLtrC), device)
+	_ = updateDevicePoint("usage_water_delta_litres_sparkling", float64(dltLtrS), device)
+	_ = updateDevicePoint("filter_warning_internal", utils.BoolToFloat(fltrWrnInt), device)
+	_ = updateDevicePoint("filter_warning_external", utils.BoolToFloat(fltrWrnExt), device)
+	_ = updateDevicePoint("filter_info_usage_litres_internal", float64(fltrNfoUseLtrInt), device)
+	_ = updateDevicePoint("filter_info_usage_days_internal", float64(fltrNfoUseDayInt), device)
+	_ = updateDevicePoint("filter_info_usage_litres_external", float64(fltrNfoUseLtrExt), device)
+	_ = updateDevicePoint("filter_info_usage_days_external", float64(fltrNfoUseDayExt), device)
+	// Pkt V2
 	_ = updateDevicePoint("filter_info_usage_litres_uv", float64(fltrNfoUseLtrUV), device)
 	_ = updateDevicePoint("filter_info_usage_days_uv", float64(fltrNfoUseDayUV), device)
 	_ = updateDevicePoint("filter_warning_uv", utils.BoolToFloat(fltrWrnUV), device)

--- a/decoder/ziphydrotap.go
+++ b/decoder/ziphydrotap.go
@@ -10,143 +10,93 @@ import (
 	"strconv"
 )
 
-const ZHTPlLenStaticV1 = 97
-const ZHTPlLenStaticV2 = 102 // 9500ms
-
-const ZHTPlLenWriteV1 = 51
-const ZHTPlLenWriteV2 = 66 // 7200ms
-
-const ZHTPlLenPollV1 = 40
-const ZHTPlLenPollV2 = 47 // 6200ms
-
-type TZipHydrotapBase struct {
-	CommonValues
-}
-
-type TZipHydrotapStatic struct {
-	LoRaFirmwareMajor       uint8  `json:"lora_firmware_major"`
-	LoRaFirmwareMinor       uint8  `json:"lora_firmware_minor"`
-	LoRaBuildMajor          uint8  `json:"lora_build_major"`
-	LoRaBuildMinor          uint8  `json:"lora_build_minor"`
-	SerialNumber            string `json:"serial_number"`
-	ModelNumber             string `json:"model_number"`
-	ProductNumber           string `json:"product_number"`
-	FirmwareVersion         string `json:"firmware_version"`
-	CalibrationDate         string `json:"calibration_date"`
-	First50LitresData       string `json:"first_50_litres_data"`
-	FilterLogDateInternal   string `json:"filter_log_date_internal"`
-	FilterLogLitresInternal int    `json:"filter_log_litres_internal"`
-	FilterLogDateExternal   string `json:"filter_log_date_external"`
-	FilterLogLitresExternal int    `json:"filter_log_litres_external"`
-	FilterLogDateUV         string `json:"filter_log_date_uv"`
-	FilterLogLitresUV       int    `json:"filter_log_litres_uv"`
-}
-
-const ZipHTTimerLength = 7
-
-type TZipHydrotapTimer struct {
-	TimeStart   int  `json:"time_start"`
-	TimeStop    int  `json:"time_stop"`
-	EnableStart bool `json:"enable_start"`
-	EnableStop  bool `json:"enable_stop"`
-}
-
-type TZipHydrotapWrite struct {
-	Time                         int                                 `json:"time"`
-	DispenseTimeBoiling          int                                 `json:"dispense_time_boiling"`
-	DispenseTimeChilled          int                                 `json:"dispense_time_chilled"`
-	DispenseTimeSparkling        int                                 `json:"dispense_time_sparkling"`
-	TemperatureSPBoiling         float32                             `json:"temperature_sp_boiling"`
-	TemperatureSPChilled         float32                             `json:"temperature_sp_chilled"`
-	TemperatureSPSparkling       float32                             `json:"temperature_sp_sparkling"`
-	SleepModeSetting             int                                 `json:"sleep_mode_setting"`
-	FilterInfoLifeLitresInternal int                                 `json:"filter_info_life_litres_internal"`
-	FilterInfoLifeMonthsInternal int                                 `json:"filter_info_life_months_internal"`
-	FilterInfoLifeLitresExternal int                                 `json:"filter_info_life_litres_external"`
-	FilterInfoLifeMonthsExternal int                                 `json:"filter_info_life_months_external"`
-	SafetyAllowTapChanges        bool                                `json:"safety_allow_tap_changes"`
-	SafetyLock                   bool                                `json:"safety_lock"`
-	SafetyHotIsolation           bool                                `json:"safety_hot_isolation"`
-	SecurityEnable               bool                                `json:"security_enable"`
-	SecurityPin                  int                                 `json:"security_pin"`
-	Timers                       [ZipHTTimerLength]TZipHydrotapTimer `json:"timers"`
-	// Packet V2
-	FilterInfoLifeLitresUV int `json:"filter_info_life_litres_uv"`
-	FilterInfoLifeMonthsUV int `json:"filter_info_life_months_uv"`
-	CO2LifeGrams           int `json:"co2_life_grams"`
-	CO2LifeMonths          int `json:"co2_life_months"`
-	CO2Pressure            int `json:"co2_pressure"`
-	CO2TankCapacity        int `json:"co2_tank_capacity"`
-	CO2AbsorptionRate      int `json:"co2_absorption_rate"`
-	SparklingFlowRate      int `json:"sparkling_flow_rate"`
-	SparklingFlushTime     int `json:"sparkling_flush_time"`
-}
-
-type TZipHydrotapPoll struct {
-	Rebooted bool `json:"rebooted"`
-	// StaticCOVFlag                     bool    `json:"static_cov_flag"`
-	// WriteCOVFlag                      bool    `json:"write_cov_flag"`
-	SleepModeStatus                   int8    `json:"sleep_mode_status"`
-	TemperatureNTCBoiling             float32 `json:"temperature_ntc_boiling"`
-	TemperatureNTCChilled             float32 `json:"temperature_ntc_chilled"`
-	TemperatureNTCStream              float32 `json:"temperature_ntc_stream"`
-	TemperatureNTCCondensor           float32 `json:"temperature_ntc_condensor"`
-	UsageEnergyKWh                    float32 `json:"usage_energy_kwh"`
-	UsageWaterDeltaDispensesBoiling   int     `json:"usage_water_delta_dispenses_boiling"`
-	UsageWaterDeltaDispensesChilled   int     `json:"usage_water_delta_dispenses_chilled"`
-	UsageWaterDeltaDispensesSparkling int     `json:"usage_water_delta_dispenses_sparkling"`
-	UsageWaterDeltaLitresBoiling      float32 `json:"usage_water_delta_litres_boiling"`
-	UsageWaterDeltaLitresChilled      float32 `json:"usage_water_delta_litres_chilled"`
-	UsageWaterDeltaLitresSparkling    float32 `json:"usage_water_delta_litres_sparkling"`
-	Fault1                            uint8   `json:"fault_1"`
-	Fault2                            uint8   `json:"fault_2"`
-	Fault3                            uint8   `json:"fault_3"`
-	Fault4                            uint8   `json:"fault_4"`
-	FilterWarningInternal             bool    `json:"filter_warning_internal"`
-	FilterWarningExternal             bool    `json:"filter_warning_external"`
-	FilterInfoUsageLitresInternal     int     `json:"filter_info_usage_litres_internal"`
-	FilterInfoUsageDaysInternal       int     `json:"filter_info_usage_days_internal"`
-	FilterInfoUsageLitresExternal     int     `json:"filter_info_usage_litres_external"`
-	FilterInfoUsageDaysExternal       int     `json:"filter_info_usage_days_external"`
-	// Packet V2
-	FilterInfoUsageLitresUV int  `json:"filter_info_usage_litres_uv"`
-	FilterInfoUsageDaysUV   int  `json:"filter_info_usage_days_uv"`
-	FilterWarningUV         bool `json:"filter_warning_uv"`
-	CO2LowGasWarning        bool `json:"co2_low_gas_warning"`
-	CO2UsageGrams           int  `json:"co2_usage_grams"`
-	CO2UsageDays            int  `json:"co2_usage_days"`
-}
-
-type TZipHydrotapWriteOnly struct {
-	Reboot            int `json:"reboot"`
-	ResetFilter       int `json:"reset_filter"`
-	RemoteCalibration int `json:"remote_calibration"`
-	ResetEnergy       int `json:"reset_energy"`
-}
-
-type TZipHydrotapStaticFull struct {
-	TZipHydrotapBase
-	TZipHydrotapStatic
-}
-
-type TZipHydrotapWriteFull struct {
-	TZipHydrotapBase
-	TZipHydrotapWrite
-}
-
-type TZipHydrotapPollFull struct {
-	TZipHydrotapBase
-	TZipHydrotapPoll
-}
-
-type TZipHydrotapAll struct {
-	TZipHydrotapBase
-	TZipHydrotapWriteOnly
-	TZipHydrotapWrite
-	TZipHydrotapPoll
-}
-
 type TZHTPayloadType int
+
+const (
+	ZHTPlLenStaticV1 = 97
+	ZHTPlLenStaticV2 = 102 // 9500ms
+	ZHTPlLenWriteV1  = 51
+	ZHTPlLenWriteV2  = 66 // 7200ms
+	ZHTPlLenPollV1   = 40
+	ZHTPlLenPollV2   = 47 // 6200ms
+	ZipHTTimerLength = 7
+)
+
+const (
+	RebootField            = "reboot"
+	ResetFilterField       = "reset_filter"
+	RemoteCalibrationField = "remote_calibration"
+	ResetEnergyField       = "reset_energy"
+)
+
+const (
+	TimeStartField   = "time_start"
+	TimeStopField    = "time_stop"
+	EnableStartField = "enable_start"
+	EnableStopField  = "enable_stop"
+)
+
+const (
+	TimeField                         = "time"
+	DispenseTimeBoilingField          = "dispense_time_boiling"
+	DispenseTimeChilledField          = "dispense_time_chilled"
+	DispenseTimeSparklingField        = "dispense_time_sparkling"
+	TemperatureSPBoilingField         = "temperature_sp_boiling"
+	TemperatureSPChilledField         = "temperature_sp_chilled"
+	TemperatureSPSparklingField       = "temperature_sp_sparkling"
+	SleepModeSettingField             = "sleep_mode_setting"
+	FilterInfoLifeLitresInternalField = "filter_info_life_litres_internal"
+	FilterInfoLifeMonthsInternalField = "filter_info_life_months_internal"
+	FilterInfoLifeLitresExternalField = "filter_info_life_litres_external"
+	FilterInfoLifeMonthsExternalField = "filter_info_life_months_external"
+	SafetyAllowTapChangesField        = "safety_allow_tap_changes"
+	SafetyLockField                   = "safety_lock"
+	SafetyHotIsolationField           = "safety_hot_isolation"
+	SecurityEnableField               = "security_enable"
+	SecurityPinField                  = "security_pin"
+	FilterInfoLifeLitresUVField       = "filter_info_life_litres_uv"
+	FilterInfoLifeMonthsUVField       = "filter_info_life_months_uv"
+	CO2LifeGramsField                 = "co2_life_grams"
+	CO2LifeMonthsField                = "co2_life_months"
+	CO2PressureField                  = "co2_pressure"
+	CO2TankCapacityField              = "co2_tank_capacity"
+	CO2AbsorptionRateField            = "co2_absorption_rate"
+	SparklingFlowRateField            = "sparkling_flow_rate"
+	SparklingFlushTimeField           = "sparkling_flush_time"
+	// TimersField                       = "timers" // Is added through loop
+)
+
+const (
+	RebootedField                          = "rebooted"
+	SleepModeStatusField                   = "sleep_mode_status"
+	TemperatureNTCBoilingField             = "temperature_ntc_boiling"
+	TemperatureNTCChilledField             = "temperature_ntc_chilled"
+	TemperatureNTCStreamField              = "temperature_ntc_stream"
+	TemperatureNTCCondensorField           = "temperature_ntc_condensor"
+	Fault1Field                            = "fault_1"
+	Fault2Field                            = "fault_2"
+	Fault3Field                            = "fault_3"
+	Fault4Field                            = "fault_4"
+	UsageEnergyKWhField                    = "usage_energy_kwh"
+	UsageWaterDeltaDispensesBoilingField   = "usage_water_delta_dispenses_boiling"
+	UsageWaterDeltaDispensesChilledField   = "usage_water_delta_dispenses_chilled"
+	UsageWaterDeltaDispensesSparklingField = "usage_water_delta_dispenses_sparkling"
+	UsageWaterDeltaLitresBoilingField      = "usage_water_delta_litres_boiling"
+	UsageWaterDeltaLitresChilledField      = "usage_water_delta_litres_chilled"
+	UsageWaterDeltaLitresSparklingField    = "usage_water_delta_litres_sparkling"
+	FilterWarningInternalField             = "filter_warning_internal"
+	FilterWarningExternalField             = "filter_warning_external"
+	FilterInfoUsageLitresInternalField     = "filter_info_usage_litres_internal"
+	FilterInfoUsageDaysInternalField       = "filter_info_usage_days_internal"
+	FilterInfoUsageLitresExternalField     = "filter_info_usage_litres_external"
+	FilterInfoUsageDaysExternalField       = "filter_info_usage_days_external"
+	FilterInfoUsageLitresUVField           = "filter_info_usage_litres_uv"
+	FilterInfoUsageDaysUVField             = "filter_info_usage_days_uv"
+	FilterWarningUVField                   = "filter_warning_uv"
+	CO2LowGasWarningField                  = "co2_low_gas_warning"
+	CO2UsageGramsField                     = "co2_usage_grams"
+	CO2UsageDaysField                      = "co2_usage_days"
+)
 
 const (
 	ErrorData = iota
@@ -164,12 +114,12 @@ func DecodeZHT(data string, devDesc *LoRaDeviceDescription, device *model.Device
 
 	updateDeviceFault(commonValues.ID, commonValues.Sensor, device.UUID, commonValues.Rssi)
 
-	err := updateDevicePoint("rssi", float64(commonValues.Rssi), device)
+	err := updateDevicePoint(RssiField, float64(commonValues.Rssi), device)
 	if err != nil {
 		return err
 	}
 
-	err = updateDevicePoint("snr", float64(commonValues.Snr), device)
+	err = updateDevicePoint(SnrField, float64(commonValues.Snr), device)
 	if err != nil {
 		return err
 	}
@@ -215,8 +165,112 @@ func CheckPayloadLengthZHT(data string) bool {
 	return false
 }
 
-func GetPointsStructZHT() interface{} {
-	return TZipHydrotapAll{}
+func GenerateTimerFieldNames() []string {
+	var timerFields []string
+
+	for i := 0; i < ZipHTTimerLength; i++ {
+		timerFields = append(timerFields,
+			fmt.Sprintf("%s_%d", TimeStartField, i),
+			fmt.Sprintf("%s_%d", TimeStopField, i),
+			fmt.Sprintf("%s_%d", EnableStartField, i),
+			fmt.Sprintf("%s_%d", EnableStopField, i),
+		)
+	}
+
+	return timerFields
+}
+
+func GetTZipHydroTapWriteOnlyFields() []string {
+	return []string{
+		RebootField,
+		ResetFilterField,
+		RemoteCalibrationField,
+		ResetEnergyField,
+	}
+}
+
+func GetTZipHydroTapWriteFields() []string {
+	tZipHydroTapWriteFields := []string{
+		TimeField,
+		DispenseTimeBoilingField,
+		DispenseTimeChilledField,
+		DispenseTimeSparklingField,
+		TemperatureSPBoilingField,
+		TemperatureSPChilledField,
+		TemperatureSPSparklingField,
+		SleepModeSettingField,
+		FilterInfoLifeLitresInternalField,
+		FilterInfoLifeMonthsInternalField,
+		FilterInfoLifeLitresExternalField,
+		FilterInfoLifeMonthsExternalField,
+		SafetyAllowTapChangesField,
+		SafetyLockField,
+		SafetyHotIsolationField,
+		SecurityEnableField,
+		SecurityPinField,
+		FilterInfoLifeLitresUVField,
+		FilterInfoLifeMonthsUVField,
+		CO2LifeGramsField,
+		CO2LifeMonthsField,
+		CO2PressureField,
+		CO2TankCapacityField,
+		CO2AbsorptionRateField,
+		SparklingFlowRateField,
+		SparklingFlushTimeField,
+	}
+	return append(tZipHydroTapWriteFields, GenerateTimerFieldNames()...)
+}
+
+func GetTZipHydroTapPollFields() []string {
+	return []string{
+		RebootedField,
+		SleepModeStatusField,
+		TemperatureNTCBoilingField,
+		TemperatureNTCChilledField,
+		TemperatureNTCStreamField,
+		TemperatureNTCCondensorField,
+		UsageEnergyKWhField,
+		UsageWaterDeltaDispensesBoilingField,
+		UsageWaterDeltaDispensesChilledField,
+		UsageWaterDeltaDispensesSparklingField,
+		UsageWaterDeltaLitresBoilingField,
+		UsageWaterDeltaLitresChilledField,
+		UsageWaterDeltaLitresSparklingField,
+		Fault1Field,
+		Fault2Field,
+		Fault3Field,
+		Fault4Field,
+		FilterWarningInternalField,
+		FilterWarningExternalField,
+		FilterInfoUsageLitresInternalField,
+		FilterInfoUsageDaysInternalField,
+		FilterInfoUsageLitresExternalField,
+		FilterInfoUsageDaysExternalField,
+		FilterInfoUsageLitresUVField,
+		FilterInfoUsageDaysUVField,
+		FilterWarningUVField,
+		CO2LowGasWarningField,
+		CO2UsageGramsField,
+		CO2UsageDaysField,
+	}
+}
+
+func GetZHTPointNames() []string {
+	commonValueFields := GetCommonValueNames()
+	tZipHydroTapWriteOnlyFields := GetTZipHydroTapWriteOnlyFields()
+	tZipHydroTapWriteFields := GetTZipHydroTapWriteFields()
+	tZipHydroTapPollFields := GetTZipHydroTapPollFields()
+
+	return append(
+		append(
+			append(
+				commonValueFields,
+				tZipHydroTapWriteOnlyFields...,
+			),
+			tZipHydroTapWriteFields...,
+		),
+		tZipHydroTapPollFields...,
+	)
 }
 
 func getPayloadBytes(data string) []byte {
@@ -245,65 +299,66 @@ func bytesToDate(bytes []byte) string {
 	return fmt.Sprintf("%d/%d/%d", bytes[0], bytes[1], bytes[2])
 }
 
-func staticPayloadDecoder(data []byte) TZipHydrotapStatic {
-	index := 1
-	fwMa := data[index]
-	index += 1
-	fwMi := data[index]
-	index += 1
-	buildMa := data[index]
-	index += 1
-	buildMi := data[index]
-	index += 1
-	sn := bytesToString(data[index : index+15])
-	index += 15
-	mn := bytesToString(data[index : index+20])
-	index += 20
-	pn := bytesToString(data[index : index+20])
-	index += 20
-	fw := bytesToString(data[index : index+20])
-	index += 20
-	calDate := bytesToDate(data[index : index+3])
-	index += 3
-	f50lDate := bytesToDate(data[index : index+3])
-	index += 3
-	filtLogDateInt := bytesToDate(data[index : index+3])
-	index += 3
-	filtLogLitresInt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	index += 2
-	filtLogDateExt := bytesToDate(data[index : index+3])
-	index += 3
-	filtLogLitresExt := int(binary.LittleEndian.Uint16(data[index : index+2]))
-	index += 2
-
-	filtLogDateUV := ""
-	filtLogLitresUV := 0
-	if data[0] >= 2 {
-		filtLogDateUV = bytesToDate(data[index : index+3])
-		index += 3
-		filtLogLitresUV = int(binary.LittleEndian.Uint16(data[index : index+2]))
-		index += 2
-	}
-
-	return TZipHydrotapStatic{
-		LoRaFirmwareMajor:       fwMa,
-		LoRaFirmwareMinor:       fwMi,
-		LoRaBuildMajor:          buildMa,
-		LoRaBuildMinor:          buildMi,
-		SerialNumber:            sn,
-		ModelNumber:             mn,
-		ProductNumber:           pn,
-		FirmwareVersion:         fw,
-		CalibrationDate:         calDate,
-		First50LitresData:       f50lDate,
-		FilterLogDateInternal:   filtLogDateInt,
-		FilterLogLitresInternal: filtLogLitresInt,
-		FilterLogDateExternal:   filtLogDateExt,
-		FilterLogLitresExternal: filtLogLitresExt,
-		FilterLogDateUV:         filtLogDateUV,
-		FilterLogLitresUV:       filtLogLitresUV,
-	}
-}
+// No usages of staticPayloadDecoder method
+// func staticPayloadDecoder(data []byte, device *model.Device) error {
+// 	index := 1
+// 	fwMa := data[index]
+// 	index += 1
+// 	fwMi := data[index]
+// 	index += 1
+// 	buildMa := data[index]
+// 	index += 1
+// 	buildMi := data[index]
+// 	index += 1
+// 	sn := bytesToString(data[index : index+15])
+// 	index += 15
+// 	mn := bytesToString(data[index : index+20])
+// 	index += 20
+// 	pn := bytesToString(data[index : index+20])
+// 	index += 20
+// 	fw := bytesToString(data[index : index+20])
+// 	index += 20
+// 	calDate := bytesToDate(data[index : index+3])
+// 	index += 3
+// 	f50lDate := bytesToDate(data[index : index+3])
+// 	index += 3
+// 	filtLogDateInt := bytesToDate(data[index : index+3])
+// 	index += 3
+// 	filtLogLitresInt := int(binary.LittleEndian.Uint16(data[index : index+2]))
+// 	index += 2
+// 	filtLogDateExt := bytesToDate(data[index : index+3])
+// 	index += 3
+// 	filtLogLitresExt := int(binary.LittleEndian.Uint16(data[index : index+2]))
+// 	index += 2
+//
+// 	filtLogDateUV := ""
+// 	filtLogLitresUV := 0
+// 	if data[0] >= 2 {
+// 		filtLogDateUV = bytesToDate(data[index : index+3])
+// 		index += 3
+// 		filtLogLitresUV = int(binary.LittleEndian.Uint16(data[index : index+2]))
+// 		index += 2
+// 	}
+//
+// 	_ = updateDevicePoint("lora_firmware_major", float64(fwMa), device)
+// 	_ = updateDevicePoint("lora_firmware_minor", float64(fwMi), device)
+// 	_ = updateDevicePoint("lora_build_major", float64(buildMa), device)
+// 	_ = updateDevicePoint("lora_build_minor", float64(buildMi), device)
+// 	_ = updateDevicePoint("serial_number", sn, device)
+// 	_ = updateDevicePoint("model_number", mn, device)
+// 	_ = updateDevicePoint("product_number", pn, device)
+// 	_ = updateDevicePoint("firmware_version", fw, device)
+// 	_ = updateDevicePoint("calibration_date", calDate, device)
+// 	_ = updateDevicePoint("first_50_litres_data", f50lDate, device)
+// 	_ = updateDevicePoint("filter_log_date_internal", filtLogDateInt, device)
+// 	_ = updateDevicePoint("filter_log_litres_internal", filtLogLitresInt, device)
+// 	_ = updateDevicePoint("filter_log_date_external", filtLogDateExt, device)
+// 	_ = updateDevicePoint("filter_log_litres_external", filtLogLitresExt, device)
+// 	_ = updateDevicePoint("filter_log_date_uv", filtLogDateUV, device)
+// 	_ = updateDevicePoint("filter_log_litres_uv", filtLogLitresUV, device)
+//
+// 	return nil
+// }
 
 func writePayloadDecoder(data []byte, device *model.Device) error {
 	index := 1
@@ -350,10 +405,10 @@ func writePayloadDecoder(data []byte, device *model.Device) error {
 		timeStop := int(u16 % 10000)
 		enableStop := u16 >= 10000
 		index += 2
-		_ = updateDevicePoint(fmt.Sprintf("time_start_%d", i), float64(timeStart), device)
-		_ = updateDevicePoint(fmt.Sprintf("enable_start_%d", i), utils.BoolToFloat(enableStart), device)
-		_ = updateDevicePoint(fmt.Sprintf("time_stop_%d", i), float64(timeStop), device)
-		_ = updateDevicePoint(fmt.Sprintf("enable_stop_%d", i), utils.BoolToFloat(enableStop), device)
+		_ = updateDevicePoint(fmt.Sprintf("%s_%d", TimeStartField, i), float64(timeStart), device)
+		_ = updateDevicePoint(fmt.Sprintf("%s_%d", TimeStopField, i), float64(timeStop), device)
+		_ = updateDevicePoint(fmt.Sprintf("%s_%d", EnableStartField, i), utils.BoolToFloat(enableStart), device)
+		_ = updateDevicePoint(fmt.Sprintf("%s_%d", EnableStopField, i), utils.BoolToFloat(enableStop), device)
 	}
 
 	filLyfLtrUV := 0
@@ -386,33 +441,33 @@ func writePayloadDecoder(data []byte, device *model.Device) error {
 		index += 2
 	}
 
-	_ = updateDevicePoint("time", float64(time), device)
-	_ = updateDevicePoint("dispense_time_boiling", float64(dispB), device)
-	_ = updateDevicePoint("dispense_time_chilled", float64(dispC), device)
-	_ = updateDevicePoint("dispense_time_sparkling", float64(dispS), device)
-	_ = updateDevicePoint("temperature_sp_boiling", float64(tempSpB), device)
-	_ = updateDevicePoint("temperature_sp_chilled", float64(tempSpC), device)
-	_ = updateDevicePoint("temperature_sp_sparkling", float64(tempSpS), device)
-	_ = updateDevicePoint("sleep_mode_setting", float64(sm), device)
-	_ = updateDevicePoint("filter_info_life_litres_internal", float64(filLyfLtrInt), device)
-	_ = updateDevicePoint("filter_info_life_months_internal", float64(filLyfMnthInt), device)
-	_ = updateDevicePoint("filter_info_life_litres_external", float64(filLyfLtrExt), device)
-	_ = updateDevicePoint("filter_info_life_months_external", float64(filLyfMnthExt), device)
-	_ = updateDevicePoint("safety_allow_tap_changes", utils.BoolToFloat(sfTap), device)
-	_ = updateDevicePoint("safety_lock", utils.BoolToFloat(sfL), device)
-	_ = updateDevicePoint("safety_hot_isolation", utils.BoolToFloat(sfHi), device)
-	_ = updateDevicePoint("security_enable", utils.BoolToFloat(secEn), device)
-	_ = updateDevicePoint("security_pin", float64(secPin), device)
+	_ = updateDevicePoint(TimeField, float64(time), device)
+	_ = updateDevicePoint(DispenseTimeBoilingField, float64(dispB), device)
+	_ = updateDevicePoint(DispenseTimeChilledField, float64(dispC), device)
+	_ = updateDevicePoint(DispenseTimeSparklingField, float64(dispS), device)
+	_ = updateDevicePoint(TemperatureSPBoilingField, float64(tempSpB), device)
+	_ = updateDevicePoint(TemperatureSPChilledField, float64(tempSpC), device)
+	_ = updateDevicePoint(TemperatureSPSparklingField, float64(tempSpS), device)
+	_ = updateDevicePoint(SleepModeSettingField, float64(sm), device)
+	_ = updateDevicePoint(FilterInfoLifeLitresInternalField, float64(filLyfLtrInt), device)
+	_ = updateDevicePoint(FilterInfoLifeMonthsInternalField, float64(filLyfMnthInt), device)
+	_ = updateDevicePoint(FilterInfoLifeLitresExternalField, float64(filLyfLtrExt), device)
+	_ = updateDevicePoint(FilterInfoLifeMonthsExternalField, float64(filLyfMnthExt), device)
+	_ = updateDevicePoint(SafetyAllowTapChangesField, utils.BoolToFloat(sfTap), device)
+	_ = updateDevicePoint(SafetyLockField, utils.BoolToFloat(sfL), device)
+	_ = updateDevicePoint(SafetyHotIsolationField, utils.BoolToFloat(sfHi), device)
+	_ = updateDevicePoint(SecurityEnableField, utils.BoolToFloat(secEn), device)
+	_ = updateDevicePoint(SecurityPinField, float64(secPin), device)
 	// Pkt V2
-	_ = updateDevicePoint("filter_info_life_litres_uv", float64(filLyfLtrUV), device)
-	_ = updateDevicePoint("filter_info_life_months_uv", float64(filLyfMnthUV), device)
-	_ = updateDevicePoint("co2_life_grams", float64(cO2LyfGrams), device)
-	_ = updateDevicePoint("co2_life_months", float64(cO2LyfMnths), device)
-	_ = updateDevicePoint("co2_pressure", float64(cO2Pressure), device)
-	_ = updateDevicePoint("co2_tank_capacity", float64(cO2TankCap), device)
-	_ = updateDevicePoint("co2_absorption_rate", float64(cO2AbsorpRate), device)
-	_ = updateDevicePoint("sparkling_flow_rate", float64(sparklFlowRate), device)
-	_ = updateDevicePoint("sparkling_flush_time", float64(sparklFlushTime), device)
+	_ = updateDevicePoint(FilterInfoLifeLitresUVField, float64(filLyfLtrUV), device)
+	_ = updateDevicePoint(FilterInfoLifeMonthsUVField, float64(filLyfMnthUV), device)
+	_ = updateDevicePoint(CO2LifeGramsField, float64(cO2LyfGrams), device)
+	_ = updateDevicePoint(CO2LifeMonthsField, float64(cO2LyfMnths), device)
+	_ = updateDevicePoint(CO2PressureField, float64(cO2Pressure), device)
+	_ = updateDevicePoint(CO2TankCapacityField, float64(cO2TankCap), device)
+	_ = updateDevicePoint(CO2AbsorptionRateField, float64(cO2AbsorpRate), device)
+	_ = updateDevicePoint(SparklingFlowRateField, float64(sparklFlowRate), device)
+	_ = updateDevicePoint(SparklingFlushTimeField, float64(sparklFlushTime), device)
 
 	return nil
 }
@@ -487,36 +542,36 @@ func pollPayloadDecoder(data []byte, device *model.Device) error {
 		index += 1
 	}
 
-	_ = updateDevicePoint("rebooted", utils.BoolToFloat(rebooted), device)
-	_ = updateDevicePoint("sleep_mode_status", float64(sms), device)
-	_ = updateDevicePoint("temperature_ntc_boiling", float64(tempB), device)
-	_ = updateDevicePoint("temperature_ntc_chilled", float64(tempC), device)
-	_ = updateDevicePoint("temperature_ntc_stream", float64(tempS), device)
-	_ = updateDevicePoint("temperature_ntc_condensor", float64(tempCond), device)
-	_ = updateDevicePoint("fault_1", float64(f1), device)
-	_ = updateDevicePoint("fault_2", float64(f2), device)
-	_ = updateDevicePoint("fault_3", float64(f3), device)
-	_ = updateDevicePoint("fault_4", float64(f4), device)
-	_ = updateDevicePoint("usage_energy_kwh", float64(kwh), device)
-	_ = updateDevicePoint("usage_water_delta_dispenses_boiling", float64(dltDispB), device)
-	_ = updateDevicePoint("usage_water_delta_dispenses_chilled", float64(dltDispC), device)
-	_ = updateDevicePoint("usage_water_delta_dispenses_sparkling", float64(dltDispS), device)
-	_ = updateDevicePoint("usage_water_delta_litres_boiling", float64(dltLtrB), device)
-	_ = updateDevicePoint("usage_water_delta_litres_chilled", float64(dltLtrC), device)
-	_ = updateDevicePoint("usage_water_delta_litres_sparkling", float64(dltLtrS), device)
-	_ = updateDevicePoint("filter_warning_internal", utils.BoolToFloat(fltrWrnInt), device)
-	_ = updateDevicePoint("filter_warning_external", utils.BoolToFloat(fltrWrnExt), device)
-	_ = updateDevicePoint("filter_info_usage_litres_internal", float64(fltrNfoUseLtrInt), device)
-	_ = updateDevicePoint("filter_info_usage_days_internal", float64(fltrNfoUseDayInt), device)
-	_ = updateDevicePoint("filter_info_usage_litres_external", float64(fltrNfoUseLtrExt), device)
-	_ = updateDevicePoint("filter_info_usage_days_external", float64(fltrNfoUseDayExt), device)
+	_ = updateDevicePoint(RebootedField, utils.BoolToFloat(rebooted), device)
+	_ = updateDevicePoint(SleepModeStatusField, float64(sms), device)
+	_ = updateDevicePoint(TemperatureNTCBoilingField, float64(tempB), device)
+	_ = updateDevicePoint(TemperatureNTCChilledField, float64(tempC), device)
+	_ = updateDevicePoint(TemperatureNTCStreamField, float64(tempS), device)
+	_ = updateDevicePoint(TemperatureNTCCondensorField, float64(tempCond), device)
+	_ = updateDevicePoint(Fault1Field, float64(f1), device)
+	_ = updateDevicePoint(Fault2Field, float64(f2), device)
+	_ = updateDevicePoint(Fault3Field, float64(f3), device)
+	_ = updateDevicePoint(Fault4Field, float64(f4), device)
+	_ = updateDevicePoint(UsageEnergyKWhField, float64(kwh), device)
+	_ = updateDevicePoint(UsageWaterDeltaDispensesBoilingField, float64(dltDispB), device)
+	_ = updateDevicePoint(UsageWaterDeltaDispensesChilledField, float64(dltDispC), device)
+	_ = updateDevicePoint(UsageWaterDeltaDispensesSparklingField, float64(dltDispS), device)
+	_ = updateDevicePoint(UsageWaterDeltaLitresBoilingField, float64(dltLtrB), device)
+	_ = updateDevicePoint(UsageWaterDeltaLitresChilledField, float64(dltLtrC), device)
+	_ = updateDevicePoint(UsageWaterDeltaLitresSparklingField, float64(dltLtrS), device)
+	_ = updateDevicePoint(FilterWarningInternalField, utils.BoolToFloat(fltrWrnInt), device)
+	_ = updateDevicePoint(FilterWarningExternalField, utils.BoolToFloat(fltrWrnExt), device)
+	_ = updateDevicePoint(FilterInfoUsageLitresInternalField, float64(fltrNfoUseLtrInt), device)
+	_ = updateDevicePoint(FilterInfoUsageDaysInternalField, float64(fltrNfoUseDayInt), device)
+	_ = updateDevicePoint(FilterInfoUsageLitresExternalField, float64(fltrNfoUseLtrExt), device)
+	_ = updateDevicePoint(FilterInfoUsageDaysExternalField, float64(fltrNfoUseDayExt), device)
 	// Pkt V2
-	_ = updateDevicePoint("filter_info_usage_litres_uv", float64(fltrNfoUseLtrUV), device)
-	_ = updateDevicePoint("filter_info_usage_days_uv", float64(fltrNfoUseDayUV), device)
-	_ = updateDevicePoint("filter_warning_uv", utils.BoolToFloat(fltrWrnUV), device)
-	_ = updateDevicePoint("co2_low_gas_warning", utils.BoolToFloat(cO2GasPressureWrn), device)
-	_ = updateDevicePoint("co2_usage_grams", float64(cO2UsgGrams), device)
-	_ = updateDevicePoint("co2_usage_days", float64(cO2UsgDays), device)
+	_ = updateDevicePoint(FilterInfoUsageLitresUVField, float64(fltrNfoUseLtrUV), device)
+	_ = updateDevicePoint(FilterInfoUsageDaysUVField, float64(fltrNfoUseDayUV), device)
+	_ = updateDevicePoint(FilterWarningUVField, utils.BoolToFloat(fltrWrnUV), device)
+	_ = updateDevicePoint(CO2LowGasWarningField, utils.BoolToFloat(cO2GasPressureWrn), device)
+	_ = updateDevicePoint(CO2UsageGramsField, float64(cO2UsgGrams), device)
+	_ = updateDevicePoint(CO2UsageDaysField, float64(cO2UsgDays), device)
 
 	return nil
 }

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -12,8 +12,6 @@ import (
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/nargs"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"reflect"
 	"strings"
 	"sync"
@@ -149,26 +147,12 @@ func (m *Module) addDevicePoints(deviceBody *model.Device) error {
 	return nil
 }
 
-func (m *Module) addPointFromName(deviceBody *model.Device, name string) (*model.Point, error) {
-	point := new(model.Point)
-	m.setNewPointFields(deviceBody, point, name)
-	point.EnableWriteable = boolean.NewFalse()
-	pnt, err := m.savePoint(point)
-	return pnt, err
-}
-
-func (m *Module) savePoint(point *model.Point) (*model.Point, error) {
-	point.EnableWriteable = boolean.NewFalse()
-	pnt, err := m.addPoint(point)
-	return pnt, err
-}
-
 func (m *Module) addPointsFromName(deviceBody *model.Device, names ...string) {
 	var points []*model.Point
 	for _, name := range names {
 		pointName := utils.GetStructFieldJSONNameByName(decoder.CommonValues{}, name)
 		point := new(model.Point)
-		m.setNewPointFields(deviceBody, point, pointName)
+		decoder.SetNewPointFields(deviceBody, point, pointName)
 		point.EnableWriteable = boolean.NewFalse()
 		points = append(points, point)
 	}
@@ -197,7 +181,7 @@ func (m *Module) addPointsFromStruct(deviceBody *model.Device, pointsRefl reflec
 			pointName = fmt.Sprintf("%s%s", pointName, postfix)
 		}
 		point := new(model.Point)
-		m.setNewPointFields(deviceBody, point, pointName)
+		decoder.SetNewPointFields(deviceBody, point, pointName)
 		point.EnableWriteable = boolean.NewFalse()
 		points = append(points, point)
 	}
@@ -219,17 +203,6 @@ func (m *Module) savePoints(points []*model.Point) {
 		}()
 	}
 	wg.Wait()
-}
-
-func (m *Module) setNewPointFields(deviceBody *model.Device, pointBody *model.Point, name string) {
-	pointBody.Enable = boolean.NewTrue()
-	pointBody.DeviceUUID = deviceBody.UUID
-	pointBody.AddressUUID = deviceBody.AddressUUID
-	pointBody.IsOutput = boolean.NewFalse()
-	pointBody.Name = cases.Title(language.English).String(name)
-	pointBody.IoNumber = name
-	pointBody.ThingType = "point"
-	pointBody.WriteMode = datatype.ReadOnly
 }
 
 // updateDevicePointsAddress by its lora id and type as in temp or lux
@@ -259,13 +232,4 @@ func (m *Module) updatePluginMessage(messageLevel, message string) error {
 		log.Errorf("updatePluginMessage() err: %s", err)
 	}
 	return err
-}
-
-func (m *Module) selectPointByIoNumber(ioNumber string, device *model.Device) *model.Point {
-	for _, pnt := range device.Points {
-		if pnt.IoNumber == ioNumber {
-			return pnt
-		}
-	}
-	return nil
 }

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -135,24 +135,21 @@ func (m *Module) addDevicePoints(deviceBody *model.Device) error {
 		return errors.New(errMsg)
 	}
 
-	points := decoder.GetDevicePointsStruct(deviceBody)
+	points := decoder.GetDevicePointNames(deviceBody)
 	// TODO: should check this before the device is even added in the wizard
-	if points == struct{}{} {
+	if len(points) == 0 {
 		log.Errorf("addDevicePoints() incorrect device model, try THLM %s", err)
 		return errors.New("addDevicePoints() no device description or points found for this device")
 	}
-	pointsRefl := reflect.ValueOf(points)
-	m.addPointsFromName(deviceBody, "Rssi", "Snr")
-	m.addPointsFromStruct(deviceBody, pointsRefl, "")
+	m.addPointsFromName(deviceBody, points...)
 	return nil
 }
 
 func (m *Module) addPointsFromName(deviceBody *model.Device, names ...string) {
 	var points []*model.Point
 	for _, name := range names {
-		pointName := utils.GetStructFieldJSONNameByName(decoder.CommonValues{}, name)
 		point := new(model.Point)
-		decoder.SetNewPointFields(deviceBody, point, pointName)
+		decoder.SetNewPointFields(deviceBody, point, name)
 		point.EnableWriteable = boolean.NewFalse()
 		points = append(points, point)
 	}

--- a/pkg/module.go
+++ b/pkg/module.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"github.com/NubeIO/lib-module-go/nmodule"
+	"github.com/NubeIO/module-core-loraraw/decoder"
 	"sync"
 )
 
@@ -22,6 +23,7 @@ func (m *Module) Init(dbHelper nmodule.DBHelper, moduleName string) error {
 	m.dbHelper = dbHelper
 	m.moduleName = moduleName
 	m.grpcMarshaller = &grpcMarshaller
+	decoder.InitGrpcMarshaller(&grpcMarshaller)
 	return nil
 }
 

--- a/pkg/router.go
+++ b/pkg/router.go
@@ -8,7 +8,6 @@ import (
 	"github.com/NubeIO/module-core-loraraw/schema"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/dto"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
-	"github.com/NubeIO/nubeio-rubix-lib-models-go/nargs"
 	"net/http"
 )
 
@@ -89,8 +88,7 @@ func CreateDevice(m *nmodule.Module, r *router.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	v := r.QueryParams.Get(nargs.WithPoints)
-	dev, err := (*m).(*Module).addDevice(device, v == "true")
+	dev, err := (*m).(*Module).addDevice(device, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/router.go
+++ b/pkg/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NubeIO/module-core-loraraw/schema"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/dto"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/nargs"
 	"net/http"
 )
 
@@ -88,7 +89,8 @@ func CreateDevice(m *nmodule.Module, r *router.Request) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	dev, err := (*m).(*Module).addDevice(device, false)
+	v := r.QueryParams.Get(nargs.WithPoints)
+	dev, err := (*m).(*Module).addDevice(device, v == "true")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Changes:
- Decoder function only returns an error (if any)
- Logic to update points is moved to decoder functions
- If the decoder doesn't find the point in the device while performing the update, it creates a point and then performs an update (shifting responsibility to auto-create points to the decoder)
- Remove the operation to create points automatically when a device is added

Resolves #28 