### PR TITLE
Release/1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [v1.3.0](https://github.com/NubeIO/module-core-loraraw/tree/v1.3.0) (2026-05-14)
+
+- Remove dependency of EnableDecryption
+- **Breaking**:
+    - If we have the serial port **`/data/socat/loRa1`** at the network level
+    - **Min version: `driver-lora >= v1.0.1-rc.5` & `driver-lora < v2.0.0-rc.1`**
+- **Note**: network without `/data/socat/loRa1` doesn't need the `lora-driver`
+
 ## [v1.3.0-rc.1](https://github.com/NubeIO/module-core-loraraw/tree/v1.3.0-rc.1) (2026-04-24)
 
 - Add MQTT support for publishing raw & decoded uplink data
@@ -12,13 +20,8 @@
 
 - Support both **Legacy** and **Rubix** LoRaRAW devices
 - **Breaking**:
-    - If we have the serial port **`/data/socat/loRa1`** at the network level (mainly for UART, Rubix devices, & a few ZipHydroTap devices)
-        - We need to change the module configuration:
-           ```yaml
-           enable_decryption: true
-           ```
-        - Otherwise, don't need to change anything
-  - **Min version: `driver-lora >= v1.0.1-rc.6` & `driver-lora < v2.0.0-rc.1`**
+    - If we have the serial port **`/data/socat/loRa1`** at the network level
+    - **Min version: `driver-lora >= v1.0.1-rc.5` & `driver-lora < v2.0.0-rc.1`**
 - **Note**: network without `/data/socat/loRa1` doesn't need the `lora-driver`
 
 ## [v1.1.2-rc.9](https://github.com/NubeIO/module-core-loraraw/tree/v1.1.2-rc.9) (2026-03-04)

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -144,72 +144,6 @@ func (m *Module) handleSerialPayload(dataHex string) {
 		return
 	}
 
-	if !codec.ValidPayload(dataHex) {
-		log.Infof("handleSerialPayload: exit, invalid payload (length=%d)", len(dataHex))
-		return
-	}
-
-	// We intentionally DO NOT publish the raw uplink here. When encryption is
-	// enabled the on-the-wire bytes are encrypted and useless to other
-	// consumers (only this module holds the key). Instead we publish the
-	// decrypted/unwrapped frame further down, once we have it. For
-	// non-encrypted paths the original hex is published as-is.
-	publishRawHex := strings.ToUpper(dataHex)
-
-	var err error
-	log.Debugf("uplink: %s", dataHex)
-	legacyDevice := false
-	address, err := codec.DecodeAddressHex(dataHex)
-	if err != nil {
-		log.Errorf("failed to decode LoRa address from hex data (length=%d): %s", len(dataHex), err)
-		return
-	}
-	log.Infof("handleSerialPayload: decoded address=%s", address)
-
-	device := m.getDeviceByLoRaAddress(address)
-	log.Infof("handleSerialPayload: initial device lookup: found=%v", device != nil)
-
-	dataBytesOrig, _ := hex.DecodeString(dataHex)
-
-	// Auto-detect legacy-encrypted frame: unknown address on the wire, but
-	// after decrypting with the default key the address resolves differently.
-	if device == nil {
-		if res, ok := m.tryLegacyDecrypt(address, dataBytesOrig); ok {
-			address = res.address
-			device = m.getDeviceByLoRaAddress(address)
-			legacyDevice = true
-			dataHex = res.dataHex
-			publishRawHex = res.publishRawHex
-			log.Infof("handleSerialPayload: legacy fallback decrypted address=%s (deviceFound=%v)", address, device != nil)
-		}
-	}
-
-	// Decode RSSI/SNR from the original frame NOW, before dataHex is potentially
-	// replaced with the decrypted legacy payload (which has RSSI/SNR stripped off).
-	rssi, err := codec.DecodeRSSI(dataHex)
-	if err != nil {
-		log.Errorf("failed to decode RSSI from hex data (address=%s, length=%d): %s", address, len(dataHex), err)
-		return
-	}
-	snr, err := codec.DecodeSNR(dataHex)
-	if err != nil {
-		log.Errorf("failed to decode SNR from hex data (address=%s, length=%d): %s", address, len(dataHex), err)
-		return
-	}
-	log.Infof("handleSerialPayload: address=%s rssi=%d snr=%.2f legacyDevice=%v", address, rssi, snr, legacyDevice)
-
-	if device == nil {
-		log.Infof("message from unknown sensor. ID: %s, RSSI: %d, SNR: %.2f", address, rssi, snr)
-		return
-	}
-	devDesc := codec.GetDeviceDescription(device, codecs.LoRaDeviceDescriptions)
-	if devDesc == &codec.NilLoRaDeviceDescription {
-		log.Errorln("nil device description found")
-		return
-	}
-	log.Infof("handleSerialPayload: matched device model=%s uuid=%s isLoRaRAW=%v",
-		device.Model, device.UUID, devDesc.IsLoRaRAW)
-
 	// Collect every decoded point value so we can publish them as a single
 	// JSON payload over MQTT once decoding is complete.
 	collected := map[string]float64{}
@@ -218,58 +152,179 @@ func (m *Module) handleSerialPayload(dataHex string) {
 		return m.updateDevicePointSuccess(name, value, dev, dd)
 	}
 
+	res := m.dispatchFrame(dataHex, m.getDeviceByLoRaAddress, successFn, m.updateDevicePointError, m.updateDeviceMetaTags, m.updateDeviceWrittenPointSuccess, m.updateDeviceWrittenPointError)
+	if !res.OK {
+		return
+	}
+
+	_ = successFn(codec.RssiField, float64(res.RSSI), res.Device, res.DevDesc)
+	_ = successFn(codec.SnrField, float64(res.SNR), res.Device, res.DevDesc)
+	m.updateDeviceFault(res.Device.Model, res.Device.UUID)
+	log.Infof("handleSerialPayload: done for address=%s model=%s", res.Address, res.Device.Model)
+
+	if m.mqttClient != nil {
+		m.mqttClient.PublishRaw(res.PublishRawHex)
+		if res.Device.AddressUUID != nil && len(collected) > 0 {
+			m.mqttClient.PublishValues(*res.Device.AddressUUID, res.Device.Name, collected)
+		}
+	}
+}
+
+// DispatchResult is the outcome of dispatchFrame. OK reports whether the
+// frame produced a usable decode (false ⇒ the caller should skip MQTT
+// publish, RSSI/SNR points, fault clearing, etc.).
+type DispatchResult struct {
+	Address       string
+	Device        *model.Device
+	DevDesc       *codec.LoRaDeviceDescription
+	DataHex       string // possibly rewritten after legacy decrypt
+	PublishRawHex string // unencrypted form suitable for MQTT republish
+	RSSI          int
+	SNR           float32
+	LegacyDevice  bool
+	OK            bool
+}
+
+// dispatchFrame is the core wire-frame decoder shared by handleSerialPayload
+// (production) and the test suite. It:
+//
+//  1. Validates and parses the wire address.
+//  2. Calls `getDevice(address)` to find the matching device. On miss it
+//     invokes the legacy-encryption auto-detect (tryLegacyDecrypt) and
+//     re-looks-up with the decrypted address.
+//  3. Decodes RSSI/SNR from the (possibly rewritten) frame.
+//  4. Dispatches to the correct decoder branch:
+//     - legacy-encrypted device  → handleLegacyDevice on the decrypted frame
+//     - LoRaRAW + plaintext      → strip + DecodeUplink directly
+//     - LoRaRAW + encrypted      → decryptLoRaRAWPkt + buildUnencryptedRawFrame + handleLoRaRAWDevice
+//     - legacy plaintext device  → handleLegacyDevice on the raw frame
+//
+// All side effects beyond point emission (MQTT publish, fault clearing,
+// rssi/snr point writes) are intentionally left to the caller so the same
+// function can be driven from unit tests without gRPC / MQTT dependencies.
+//
+// The caller-supplied `getDevice` callback is the only injection point: in
+// production it is `m.getDeviceByLoRaAddress` (a gRPC DB lookup); in tests it
+// is a closure over a mock device.
+func (m *Module) dispatchFrame(
+	dataHex string,
+	getDevice func(address string) *model.Device,
+	successFn codec.UpdateDevicePointFunc,
+	errorFn codec.UpdateDevicePointErrorFunc,
+	metaFn codec.UpdateDeviceMetaTagsFunc,
+	writtenSuccessFn codec.UpdateDeviceWrittenPointFunc,
+	writtenErrorFn codec.UpdateDeviceWrittenPointErrorFunc,
+) DispatchResult {
+	if !codec.ValidPayload(dataHex) {
+		log.Infof("dispatchFrame: exit, invalid payload (length=%d)", len(dataHex))
+		return DispatchResult{}
+	}
+
+	publishRawHex := strings.ToUpper(dataHex)
+
+	log.Debugf("uplink: %s", dataHex)
+	legacyDevice := false
+	address, err := codec.DecodeAddressHex(dataHex)
+	if err != nil {
+		log.Errorf("failed to decode LoRa address from hex data (length=%d): %s", len(dataHex), err)
+		return DispatchResult{}
+	}
+	log.Infof("dispatchFrame: decoded address=%s", address)
+
+	device := getDevice(address)
+	log.Infof("dispatchFrame: initial device lookup: found=%v", device != nil)
+
+	dataBytesOrig, _ := hex.DecodeString(dataHex)
+
+	// Auto-detect legacy-encrypted frame: unknown address on the wire, but
+	// after decrypting with the default key the address resolves differently.
+	if device == nil {
+		if res, ok := m.tryLegacyDecrypt(address, dataBytesOrig); ok {
+			address = res.address
+			device = getDevice(address)
+			legacyDevice = true
+			dataHex = res.dataHex
+			publishRawHex = res.publishRawHex
+			log.Infof("dispatchFrame: legacy fallback decrypted address=%s (deviceFound=%v)", address, device != nil)
+		}
+	}
+
+	rssi, err := codec.DecodeRSSI(dataHex)
+	if err != nil {
+		log.Errorf("failed to decode RSSI from hex data (address=%s, length=%d): %s", address, len(dataHex), err)
+		return DispatchResult{}
+	}
+	snr, err := codec.DecodeSNR(dataHex)
+	if err != nil {
+		log.Errorf("failed to decode SNR from hex data (address=%s, length=%d): %s", address, len(dataHex), err)
+		return DispatchResult{}
+	}
+	log.Infof("dispatchFrame: address=%s rssi=%d snr=%.2f legacyDevice=%v", address, rssi, snr, legacyDevice)
+
+	if device == nil {
+		log.Infof("message from unknown sensor. ID: %s, RSSI: %d, SNR: %.2f", address, rssi, snr)
+		return DispatchResult{}
+	}
+	devDesc := codec.GetDeviceDescription(device, codecs.LoRaDeviceDescriptions)
+	if devDesc == &codec.NilLoRaDeviceDescription {
+		log.Errorln("nil device description found")
+		return DispatchResult{}
+	}
+	log.Infof("dispatchFrame: matched device model=%s uuid=%s isLoRaRAW=%v",
+		device.Model, device.UUID, devDesc.IsLoRaRAW)
+
 	if legacyDevice {
-		log.Infof("handleSerialPayload: taking legacy decrypted handler path for address=%s", address)
+		log.Infof("dispatchFrame: taking legacy decrypted handler path for address=%s", address)
 		dataBytes, _ := hex.DecodeString(dataHex)
-		m.handleLegacyDevice(device, devDesc, dataHex, dataBytes, successFn)
+		m.handleLegacyDevice(device, devDesc, dataHex, dataBytes, successFn, errorFn, metaFn)
 	} else if devDesc.IsLoRaRAW {
 		// Auto-detect: an unencrypted LoRaRAW frame has an exact length of
 		// header + innerLen + 2 (rssi/snr). Anything else is treated as
 		// encrypted and verified via CMAC inside aesutils.Decrypt.
 		dataBytes := dataBytesOrig
 		if isUnencryptedLoRaRAW(dataBytes) {
-			log.Infof("handleSerialPayload: detected unencrypted LoRaRAW for address=%s", address)
+			log.Infof("dispatchFrame: detected unencrypted LoRaRAW for address=%s", address)
 			payload := utils.StripLoRaRAWPayload(dataBytes)
 			if err := devDesc.DecodeUplink(dataHex, payload, devDesc, device,
-				successFn, m.updateDevicePointError, m.updateDeviceMetaTags); err != nil {
+				successFn, errorFn, metaFn); err != nil {
 				log.Errorf("error decoding unencrypted LoRaRAW uplink: %v", err)
 			}
 		} else {
-			log.Infof("handleSerialPayload: attempting LoRaRAW decrypt for address=%s", address)
+			log.Infof("dispatchFrame: attempting LoRaRAW decrypt for address=%s", address)
 			keyBytes, err := m.getEncryptionKey(device)
 			if err != nil {
 				log.Errorf("error decoding device key: %s", err)
-				return
+				return DispatchResult{}
 			}
 			decodedDataBytes, derr := decryptLoRaRAWPkt(dataBytes, keyBytes)
 			if derr != nil {
 				// CMAC mismatch or otherwise not encrypted with this key.
 				log.Errorf("error decrypting data (address: %s): %s", address, derr)
-				return
+				return DispatchResult{}
 			}
-			log.Infof("handleSerialPayload: LoRaRAW decrypt ok, decodedLen=%d", len(decodedDataBytes))
-			// Rebuild the frame as it would have appeared unencrypted on the wire
-			// so downstream MQTT consumers don't need the key.
+			log.Infof("dispatchFrame: LoRaRAW decrypt ok, decodedLen=%d", len(decodedDataBytes))
+			// Rebuild the frame as it would have appeared unencrypted on the
+			// wire so downstream MQTT consumers don't need the key.
 			if pub, ok := buildUnencryptedRawFrame(decodedDataBytes, dataBytes); ok {
 				publishRawHex = strings.ToUpper(hex.EncodeToString(pub))
 			}
-			m.handleLoRaRAWDevice(device, devDesc, dataHex, decodedDataBytes, keyBytes, successFn)
+			m.handleLoRaRAWDevice(device, devDesc, dataHex, decodedDataBytes, keyBytes, successFn, errorFn, metaFn, writtenSuccessFn, writtenErrorFn)
 		}
 	} else {
-		log.Infof("handleSerialPayload: taking legacy plaintext handler path for address=%s", address)
-		m.handleLegacyDevice(device, devDesc, dataHex, dataBytesOrig, successFn)
+		log.Infof("dispatchFrame: taking legacy plaintext handler path for address=%s", address)
+		m.handleLegacyDevice(device, devDesc, dataHex, dataBytesOrig, successFn, errorFn, metaFn)
 	}
 
-	_ = successFn(codec.RssiField, float64(rssi), device, devDesc)
-	_ = successFn(codec.SnrField, float64(snr), device, devDesc)
-	m.updateDeviceFault(device.Model, device.UUID)
-	log.Infof("handleSerialPayload: done for address=%s model=%s", address, device.Model)
-
-	if m.mqttClient != nil {
-		m.mqttClient.PublishRaw(publishRawHex)
-		if device.AddressUUID != nil && len(collected) > 0 {
-			m.mqttClient.PublishValues(*device.AddressUUID, device.Name, collected)
-		}
+	return DispatchResult{
+		Address:       address,
+		Device:        device,
+		DevDesc:       devDesc,
+		DataHex:       dataHex,
+		PublishRawHex: publishRawHex,
+		RSSI:          rssi,
+		SNR:           snr,
+		LegacyDevice:  legacyDevice,
+		OK:            true,
 	}
 }
 
@@ -364,19 +419,19 @@ func buildUnencryptedRawFrame(decoded, original []byte) ([]byte, bool) {
 	return out, true
 }
 
-func (m *Module) handleLegacyDevice(device *model.Device, devDesc *codec.LoRaDeviceDescription, dataHex string, dataBytes []byte, successFn codec.UpdateDevicePointFunc) {
+func (m *Module) handleLegacyDevice(device *model.Device, devDesc *codec.LoRaDeviceDescription, dataHex string, dataBytes []byte, successFn codec.UpdateDevicePointFunc, errorFn codec.UpdateDevicePointErrorFunc, metaFn codec.UpdateDeviceMetaTagsFunc) {
 	if !devDesc.CheckLength(dataHex) {
 		log.Errorf("invalid legacy payload length")
 		return
 	}
 
-	err := devDesc.DecodeUplink(dataHex, dataBytes, devDesc, device, successFn, m.updateDevicePointError, m.updateDeviceMetaTags)
+	err := devDesc.DecodeUplink(dataHex, dataBytes, devDesc, device, successFn, errorFn, metaFn)
 	if err != nil {
 		log.Errorf("error decoding legacy uplink: %v", err)
 	}
 }
 
-func (m *Module) handleLoRaRAWDevice(device *model.Device, devDesc *codec.LoRaDeviceDescription, dataHex string, dataBytes []byte, keyBytes []byte, successFn codec.UpdateDevicePointFunc) {
+func (m *Module) handleLoRaRAWDevice(device *model.Device, devDesc *codec.LoRaDeviceDescription, dataHex string, dataBytes []byte, keyBytes []byte, successFn codec.UpdateDevicePointFunc, errorFn codec.UpdateDevicePointErrorFunc, metaFn codec.UpdateDeviceMetaTagsFunc, writtenSuccessFn codec.UpdateDeviceWrittenPointFunc, writtenErrorFn codec.UpdateDeviceWrittenPointErrorFunc) {
 	if !utils.CheckLoRaRAWPayloadLength(dataBytes) {
 		log.Errorf("LoRaRaw payload length mismatched")
 		return
@@ -385,16 +440,18 @@ func (m *Module) handleLoRaRAWDevice(device *model.Device, devDesc *codec.LoRaDe
 
 	opts := getOpts(dataBytes)
 	switch opts {
+	case utils.LORARAW_OPTS_UNCONFIRMED_UPLINK:
+		_ = devDesc.DecodeUplink(dataHex, payload, devDesc, device, successFn, errorFn, metaFn)
 	case utils.LORARAW_OPTS_CONFIRMED_UPLINK:
 		m.handleConfirmedOpt(dataBytes, keyBytes)
-		devDesc.DecodeUplink(dataHex, payload, devDesc, device, successFn, m.updateDevicePointError, m.updateDeviceMetaTags)
+		_ = devDesc.DecodeUplink(dataHex, payload, devDesc, device, successFn, errorFn, metaFn)
 	case utils.LORARAW_OPTS_RESPONSE:
 		if len(dataBytes) <= utils.LORARAW_NONCE_POSITION {
 			log.Errorf("dataBytes too short for response: length %d, need at least %d", len(dataBytes), utils.LORARAW_NONCE_POSITION+1)
 			return
 		}
 		msgId := dataBytes[utils.LORARAW_NONCE_POSITION]
-		devDesc.DecodeResponse(dataHex, payload, msgId, devDesc, device, m.updateDeviceWrittenPointSuccess, m.updateDeviceWrittenPointError, m.updateDeviceMetaTags)
+		_ = devDesc.DecodeResponse(dataHex, payload, msgId, devDesc, device, writtenSuccessFn, writtenErrorFn, metaFn)
 	default:
 		log.Warnf("unhandled LoRaRAW option: %d", opts)
 	}

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -167,42 +167,20 @@ func (m *Module) handleSerialPayload(dataHex string) {
 	log.Infof("handleSerialPayload: decoded address=%s", address)
 
 	device := m.getDeviceByLoRaAddress(address)
-	log.Infof("handleSerialPayload: initial device lookup: found=%v, enableDecryption=%v",
-		device != nil, m.config.EnableDecryption)
+	log.Infof("handleSerialPayload: initial device lookup: found=%v", device != nil)
 
-	if device == nil && m.config.EnableDecryption {
-		log.Infof("handleSerialPayload: attempting legacy decryption fallback for unknown address=%s", address)
-		// maybe it's a legacy device (droplet, microedge, ziphydrotap)
-		keyBytes, err := hex.DecodeString(m.config.DefaultKey)
-		if err != nil {
-			log.Errorf("error decoding default key: %s", err)
-			return
-		}
-		dataBytesOrig, _ := hex.DecodeString(dataHex)
-		dataLegacy, err := decryptLegacy(dataBytesOrig, keyBytes)
-		if err == nil {
-			log.Infof("handleSerialPayload: legacy decrypt succeeded, decryptedLen=%d", len(dataLegacy))
-			address, err = codec.DecodeAddressBytes(dataLegacy)
-			if err != nil {
-				log.Errorf("failed to decode LoRa address from legacy bytes (length=%d): %s", len(dataLegacy), err)
-			}
-			address = strings.ToUpper(address)
+	dataBytesOrig, _ := hex.DecodeString(dataHex)
+
+	// Auto-detect legacy-encrypted frame: unknown address on the wire, but
+	// after decrypting with the default key the address resolves differently.
+	if device == nil {
+		if res, ok := m.tryLegacyDecrypt(address, dataBytesOrig); ok {
+			address = res.address
 			device = m.getDeviceByLoRaAddress(address)
 			legacyDevice = true
-			dataHex = hex.EncodeToString(dataLegacy)
-			// Publish a raw frame that looks the way the wire looked before
-			// the source started encrypting: decrypted body + original
-			// rssi/snr trailer.
-			if len(dataBytesOrig) >= 2 {
-				pubBytes := append([]byte{}, dataLegacy...)
-				pubBytes = append(pubBytes, dataBytesOrig[len(dataBytesOrig)-2:]...)
-				publishRawHex = strings.ToUpper(hex.EncodeToString(pubBytes))
-			} else {
-				publishRawHex = strings.ToUpper(dataHex)
-			}
-			log.Infof("handleSerialPayload: legacy fallback resolved address=%s, deviceFound=%v", address, device != nil)
-		} else {
-			log.Infof("handleSerialPayload: legacy decrypt failed: %s", err)
+			dataHex = res.dataHex
+			publishRawHex = res.publishRawHex
+			log.Infof("handleSerialPayload: legacy fallback decrypted address=%s (deviceFound=%v)", address, device != nil)
 		}
 	}
 
@@ -240,56 +218,46 @@ func (m *Module) handleSerialPayload(dataHex string) {
 		return m.updateDevicePointSuccess(name, value, dev, dd)
 	}
 
-	if !legacyDevice && m.config.EnableDecryption {
-		log.Infof("handleSerialPayload: taking LoRaRAW decrypt path for address=%s", address)
-		keyBytes, err := m.getEncryptionKey(device)
-		if err != nil {
-			log.Errorf("error decoding default key: %s", err)
-			return
-		}
-		dataBytes, _ := hex.DecodeString(dataHex)
-		decodedDataBytes, err := decryptLoRaRAWPkt(dataBytes, keyBytes)
-		if err != nil {
-			log.Errorf("error decrypting data: (address: %s) %s", address, err)
-			return
-		}
-		log.Infof("handleSerialPayload: LoRaRAW decrypt ok, decodedLen=%d, dispatching to LoRaRAW handler", len(decodedDataBytes))
-		// Rebuild the frame as it would have appeared unencrypted on the wire:
-		// [addr:4][opts:1][nonce:1][len:1][inner payload:len][cmac:4][rssi:1][snr:1]
-		// This gives downstream MQTT consumers a stable, decodable frame that
-		// does not depend on holding the encryption key.
-		if pub, ok := buildUnencryptedRawFrame(decodedDataBytes, dataBytes); ok {
-			publishRawHex = strings.ToUpper(hex.EncodeToString(pub))
-		}
-		m.handleLoRaRAWDevice(device, devDesc, dataHex, decodedDataBytes, keyBytes, successFn)
-	} else if !legacyDevice && !m.config.EnableDecryption && devDesc.IsLoRaRAW {
-		// Unencrypted LoRaRAW frame: same wire framing minus encryption and CMAC.
-		// Layout: [addr:4][opts:1][nonce:1][len:1][payload:len][rssi:1][snr:1]
-		log.Infof("handleSerialPayload: taking unencrypted LoRaRAW path for address=%s", address)
-		dataBytes, _ := hex.DecodeString(dataHex)
-		if len(dataBytes) < utils.LORARAW_PAYLOAD_START+2 {
-			log.Errorf("unencrypted LoRaRAW frame too short: length %d, need at least %d",
-				len(dataBytes), utils.LORARAW_PAYLOAD_START+2)
-			return
-		}
-		innerLen := utils.GetLoRaRAWInnerPayloadLength(dataBytes)
-		// Need: header(7) + payload(innerLen) + rssi/snr(2) bytes.
-		if len(dataBytes) < utils.LORARAW_PAYLOAD_START+innerLen+2 {
-			log.Errorf("unencrypted LoRaRAW frame truncated: need %d bytes, have %d",
-				utils.LORARAW_PAYLOAD_START+innerLen+2, len(dataBytes))
-			return
-		}
-		payload := utils.StripLoRaRAWPayload(dataBytes)
-		log.Infof("handleSerialPayload: unencrypted LoRaRAW ok, innerLen=%d, dispatching to decoder", innerLen)
-		if err := devDesc.DecodeUplink(dataHex, payload, devDesc, device,
-			successFn, m.updateDevicePointError, m.updateDeviceMetaTags); err != nil {
-			log.Errorf("error decoding unencrypted LoRaRAW uplink: %v", err)
-		}
-	} else {
-		log.Infof("handleSerialPayload: taking legacy handler path (legacyDevice=%v, enableDecryption=%v)",
-			legacyDevice, m.config.EnableDecryption)
+	if legacyDevice {
+		log.Infof("handleSerialPayload: taking legacy decrypted handler path for address=%s", address)
 		dataBytes, _ := hex.DecodeString(dataHex)
 		m.handleLegacyDevice(device, devDesc, dataHex, dataBytes, successFn)
+	} else if devDesc.IsLoRaRAW {
+		// Auto-detect: an unencrypted LoRaRAW frame has an exact length of
+		// header + innerLen + 2 (rssi/snr). Anything else is treated as
+		// encrypted and verified via CMAC inside aesutils.Decrypt.
+		dataBytes := dataBytesOrig
+		if isUnencryptedLoRaRAW(dataBytes) {
+			log.Infof("handleSerialPayload: detected unencrypted LoRaRAW for address=%s", address)
+			payload := utils.StripLoRaRAWPayload(dataBytes)
+			if err := devDesc.DecodeUplink(dataHex, payload, devDesc, device,
+				successFn, m.updateDevicePointError, m.updateDeviceMetaTags); err != nil {
+				log.Errorf("error decoding unencrypted LoRaRAW uplink: %v", err)
+			}
+		} else {
+			log.Infof("handleSerialPayload: attempting LoRaRAW decrypt for address=%s", address)
+			keyBytes, err := m.getEncryptionKey(device)
+			if err != nil {
+				log.Errorf("error decoding device key: %s", err)
+				return
+			}
+			decodedDataBytes, derr := decryptLoRaRAWPkt(dataBytes, keyBytes)
+			if derr != nil {
+				// CMAC mismatch or otherwise not encrypted with this key.
+				log.Errorf("error decrypting data (address: %s): %s", address, derr)
+				return
+			}
+			log.Infof("handleSerialPayload: LoRaRAW decrypt ok, decodedLen=%d", len(decodedDataBytes))
+			// Rebuild the frame as it would have appeared unencrypted on the wire
+			// so downstream MQTT consumers don't need the key.
+			if pub, ok := buildUnencryptedRawFrame(decodedDataBytes, dataBytes); ok {
+				publishRawHex = strings.ToUpper(hex.EncodeToString(pub))
+			}
+			m.handleLoRaRAWDevice(device, devDesc, dataHex, decodedDataBytes, keyBytes, successFn)
+		}
+	} else {
+		log.Infof("handleSerialPayload: taking legacy plaintext handler path for address=%s", address)
+		m.handleLegacyDevice(device, devDesc, dataHex, dataBytesOrig, successFn)
 	}
 
 	_ = successFn(codec.RssiField, float64(rssi), device, devDesc)
@@ -303,6 +271,63 @@ func (m *Module) handleSerialPayload(dataHex string) {
 			m.mqttClient.PublishValues(*device.AddressUUID, device.Name, collected)
 		}
 	}
+}
+
+// legacyDecryptResult holds the rewritten frame produced by tryLegacyDecrypt.
+type legacyDecryptResult struct {
+	address       string
+	dataHex       string
+	publishRawHex string
+}
+
+// tryLegacyDecrypt attempts to decrypt the frame with the default legacy key
+// and reports success only when the address actually changes after decryption
+// (i.e. the bytes really were legacy-encrypted). It returns the rewritten
+// address, dataHex and publishRawHex on success.
+func (m *Module) tryLegacyDecrypt(address string, dataBytesOrig []byte) (legacyDecryptResult, bool) {
+	keyBytes, err := hex.DecodeString(m.config.DefaultKey)
+	if err != nil {
+		log.Errorf("tryLegacyDecrypt: error decoding default key: %s", err)
+		return legacyDecryptResult{}, false
+	}
+	dataLegacy, err := decryptLegacy(dataBytesOrig, keyBytes)
+	if err != nil {
+		log.Infof("tryLegacyDecrypt: decrypt failed: %s", err)
+		return legacyDecryptResult{}, false
+	}
+	addr2, err := codec.DecodeAddressBytes(dataLegacy)
+	if err != nil {
+		log.Infof("tryLegacyDecrypt: address decode failed: %s", err)
+		return legacyDecryptResult{}, false
+	}
+	addr2 = strings.ToUpper(addr2)
+	if addr2 == address {
+		// Address unchanged → bytes were already plaintext (or not encrypted
+		// with this key). Nothing to do.
+		log.Infof("tryLegacyDecrypt: address unchanged (%s), skipping", addr2)
+		return legacyDecryptResult{}, false
+	}
+	dataHex := hex.EncodeToString(dataLegacy)
+	publishRawHex := strings.ToUpper(dataHex)
+	if len(dataBytesOrig) >= 2 {
+		pubBytes := append([]byte{}, dataLegacy...)
+		pubBytes = append(pubBytes, dataBytesOrig[len(dataBytesOrig)-2:]...)
+		publishRawHex = strings.ToUpper(hex.EncodeToString(pubBytes))
+	}
+	return legacyDecryptResult{address: addr2, dataHex: dataHex, publishRawHex: publishRawHex}, true
+}
+
+// isUnencryptedLoRaRAW returns true when the frame length exactly matches the
+// plaintext LoRaRAW layout: header + inner payload + rssi/snr (2 bytes).
+// Encrypted frames are always longer because the inner payload is AES-padded
+// to a 16-byte block and followed by a 4-byte CMAC, so an exact length match
+// is a reliable, key-independent indicator that the frame is unencrypted.
+func isUnencryptedLoRaRAW(dataBytes []byte) bool {
+	if len(dataBytes) < utils.LORARAW_PAYLOAD_START+2 {
+		return false
+	}
+	innerLen := utils.GetLoRaRAWInnerPayloadLength(dataBytes)
+	return len(dataBytes) == utils.LORARAW_PAYLOAD_START+innerLen+2
 }
 
 // buildUnencryptedRawFrame takes a decrypted LoRaRAW frame (as produced by

--- a/pkg/app_encrypted_test.go
+++ b/pkg/app_encrypted_test.go
@@ -1,115 +1,129 @@
 package pkg
 
 import (
-	"encoding/hex"
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/NubeIO/module-core-loraraw/codec"
 	"github.com/NubeIO/module-core-loraraw/schema"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
-	log "github.com/sirupsen/logrus"
 )
 
-func runEncryptedTests(tests []TestStruct, mockDevice *model.Device, t *testing.T) {
-	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
-			currTest = &tt
-			currIndex = 0
-			fmt.Printf("TEST %s\r\n", tt.Name)
-			dataBytes, err := hex.DecodeString(tt.Data)
-			if err != nil {
-				log.Errorf("hex decode error: %s", err)
-				return
+// testDefaultKey is declared in payload_test.go and shared across tests.
+
+// Reusable noop callbacks.
+var (
+	noopPointErr = func(_ string, _ error, _ *model.Device, _ *codec.LoRaDeviceDescription) error {
+		return nil
+	}
+	noopMetaTags   = func(_ string, _ []*model.DeviceMetaTag) error { return nil }
+	noopWrittenOK  = func(_ string, _ float64, _ uint8, _ *model.Device) error { return nil }
+	noopWrittenErr = func(_ string, _ error, _ uint8, _ *model.Device) error { return nil }
+)
+
+// newMockGetDevice returns a getDevice closure that simulates a real DB
+// lookup. Bound mocks (mockDevice.AddressUUID set) hit only on a matching
+// address — what production sees for a known LoRaRAW device. Unbound mocks
+// (AddressUUID nil, e.g. legacy fixtures whose wire address is random
+// ciphertext) miss on the wire address and hit on any OTHER address,
+// representing "DB knows about the post-decrypt device but not the
+// pre-decrypt one." This is purely address-driven; it does NOT depend on
+// dispatchFrame's call count, so the test stays correct even if the
+// dispatcher's lookup pattern changes.
+func newMockGetDevice(mockDevice *model.Device, wireAddr string) func(string) *model.Device {
+	bound := mockDevice.AddressUUID != nil
+	return func(addr string) *model.Device {
+		if bound {
+			if strings.EqualFold(*mockDevice.AddressUUID, addr) {
+				return mockDevice
 			}
-			keyBytes, err := hex.DecodeString("0301021604050f07e6095a0b0c12630f")
-			if err != nil {
-				log.Errorf("hex decode key error: %s", err)
-				return
-			}
-			dataLegacy, err := decryptLegacy(dataBytes, keyBytes)
-			if err == nil {
-				tt.Data = hex.EncodeToString(dataLegacy)
-			}
-			err = decodeData(tt.Data, mockDevice, updateDevicePointMock, updateDeviceMetaTagsMock)
-			if err != nil {
-				log.Errorf("decode error: %v\r\n", err)
-			}
-		})
+			return nil
+		}
+		// Unbound: pretend the wire address is unknown (legacy ciphertext)
+		// but the decrypted address resolves to the mock device.
+		if strings.EqualFold(addr, wireAddr) {
+			return nil
+		}
+		return mockDevice
 	}
 }
 
-func runEncryptedRubixTests(tests []TestStruct, mockDevice *model.Device, t *testing.T) {
-	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
-			currTest = &tt
-			currIndex = 0
-			dataBytes, err := hex.DecodeString(tt.Data)
-			if err != nil {
-				log.Errorf("hex decode error: %s", err)
-				return
+// assertPoints verifies that `got` contains every expected (name, value)
+// pair within float-equality tolerance. Extra points are logged only when
+// `testing -v` is on — they're useful for fixture development but noise in
+// CI summaries.
+func assertPoints(t *testing.T, want []TestPoint, got map[string]float64) {
+	t.Helper()
+	expected := make(map[string]float64, len(want))
+	for _, p := range want {
+		expected[p.Name] = p.Value
+	}
+	for name, v := range expected {
+		gv, ok := got[name]
+		if !ok {
+			t.Errorf("missing point %q (expected %v)", name, v)
+			continue
+		}
+		if !almostEqual(gv, v) {
+			t.Errorf("point %q: expected %v, got %v", name, v, gv)
+		}
+	}
+	if testing.Verbose() {
+		for name, v := range got {
+			if _, ok := expected[name]; !ok {
+				t.Logf("extra point %q = %v (not asserted)", name, v)
 			}
-			keyBytes, err := hex.DecodeString("0301021604050F07E6095A0B0C12630F")
-			if err != nil {
-				log.Errorf("hex decode key error: %s", err)
-				return
-			}
-			decrypted, err := decryptLoRaRAWPkt(dataBytes, keyBytes)
-			if err != nil {
-				log.Errorf("error decrypting data: %s", err)
-				return
-			}
-			err = decodeData(hex.EncodeToString(decrypted), mockDevice, updateDevicePointMock, updateDeviceMetaTagsMock)
-			if err != nil {
-				log.Errorf("error decode data: %s", err)
-			}
-		})
+		}
 	}
 }
 
-// runEncryptedZHTTests decrypts each raw LoRaRAW frame with the shared test
-// key, then dispatches the inner payload through the same code path the live
-// pipeline uses (decodeData -> DecodeZHT). The test fails if decryption or
-// decoding reports an error, guarding against regressions of the ZHT decoder
-// (e.g. decoding the raw address instead of the stripped payload).
+// runDispatchTests drives every fixture (legacy AES, legacy plaintext,
+// encrypted LoRaRAW, plaintext LoRaRAW) through the PRODUCTION dispatcher
+// `m.dispatchFrame` (see pkg/app.go). The only test-side wiring is:
 //
-// All decoded points are logged so fixtures can be extended with exact values
-// in the future without touching the runner.
-func runEncryptedZHTTests(tests []TestStruct, mockDevice *model.Device, t *testing.T) {
-	keyBytes, err := hex.DecodeString("0301021604050F07E6095A0B0C12630F")
-	if err != nil {
-		t.Fatalf("hex decode key error: %s", err)
-	}
-
+//   - An address-keyed mock `getDevice` (see newMockGetDevice).
+//   - A `capture` callback that stores emitted point values in a map.
+//   - Package-level noop callbacks for everything else.
+//
+// This keeps tests from drifting when handleSerialPayload's branching
+// changes — both production and tests call the same dispatchFrame.
+func runDispatchTests(tests []TestStruct, mockDevice *model.Device, t *testing.T) {
+	t.Helper()
+	m := &Module{config: &Config{DefaultKey: testDefaultKey}}
 	for _, tt := range tests {
+		tt := tt // capture for parallel safety / loop-variable hygiene
 		t.Run(tt.Name, func(t *testing.T) {
-			currTest = &tt
-			currIndex = 0
-
-			dataBytes, err := hex.DecodeString(tt.Data)
+			wireAddr, err := codec.DecodeAddressHex(tt.Data)
 			if err != nil {
-				t.Fatalf("hex decode error: %s", err)
+				t.Fatalf("decode wire address: %s", err)
 			}
-			decrypted, err := decryptLoRaRAWPkt(dataBytes, keyBytes)
-			if err != nil {
-				t.Fatalf("decryptLoRaRAWPkt failed: %s", err)
-			}
+			wireAddr = strings.ToUpper(wireAddr)
 
-			capture := func(name string, value float64, device *model.Device, devDesc *codec.LoRaDeviceDescription) error {
-				t.Logf("  %s = %f", name, value)
-				return updateDevicePointMock(name, value, device, devDesc)
+			got := map[string]float64{}
+			capture := func(name string, value float64, _ *model.Device, _ *codec.LoRaDeviceDescription) error {
+				got[name] = value
+				return nil
 			}
 
-			err = decodeData(hex.EncodeToString(decrypted), mockDevice, capture, updateDeviceMetaTagsMock)
-			if err != nil {
-				t.Fatalf("decodeData failed: %s", err)
+			res := m.dispatchFrame(
+				tt.Data,
+				newMockGetDevice(mockDevice, wireAddr),
+				capture, noopPointErr, noopMetaTags,
+				noopWrittenOK, noopWrittenErr,
+			)
+			if !res.OK {
+				t.Fatalf("dispatchFrame returned not-OK")
 			}
+			t.Logf("dispatch: address=%s model=%s legacy=%v rssi=%d snr=%.2f publishRawHex=%s",
+				res.Address, res.Device.Model, res.LegacyDevice, res.RSSI, res.SNR, res.PublishRawHex)
+
+			assertPoints(t, tt.Values, got)
 		})
 	}
 }
 
-// TestMicroEdge1Payload ...
-func TestMicroEdge1Payload(t *testing.T) {
+// TestMicroEdgeV1Payload ...
+func TestMicroEdgeV1Payload(t *testing.T) {
 	test = t
 	mockDevice := &model.Device{
 		Name: "MicroEdge",
@@ -143,11 +157,11 @@ func TestMicroEdge1Payload(t *testing.T) {
 		},
 	}
 
-	runEncryptedTests(tests, mockDevice, t)
+	runDispatchTests(tests, mockDevice, t)
 }
 
-// TestEncryotedDropletPayload ...
-func TestEncryotedDropletPayload(t *testing.T) {
+// TestEncryptedDropletPayload ...
+func TestEncryptedDropletPayload(t *testing.T) {
 	test = t
 	mockDevice := &model.Device{
 		Name: "Droplet",
@@ -181,66 +195,25 @@ func TestEncryotedDropletPayload(t *testing.T) {
 			},
 			[]*model.DeviceMetaTag{},
 		},
-	}
-
-	runEncryptedTests(tests, mockDevice, t)
-}
-
-// TestEncryptedRubixPayload ...
-func TestEncryptedRubixPayload(t *testing.T) {
-	test = t
-	mockDevice := &model.Device{
-		Name: "Rubix",
-		CommonDevice: model.CommonDevice{
-			Model: "Rubix",
-		},
-	}
-
-	tests := []TestStruct{
-		{"RubixOne",
-			"5CC08E7B0547C75CF319679F441CE5E245791166007507AD486373E723865A51C914B42EDC256D94120EBA8CAE0C26BC7B23CBC57ADE51C34A26",
+		// Real legacy-encrypted Droplet frame captured from production logs on
+		// 2026-05-14. Wire address 355055BD decrypts (default key) to device
+		// address C3B2B971 -> THLM model "dr3". Regression for the auto-detect
+		// legacy fallback path in handleSerialPayload.
+		{"DropletLegacyAutoDetect",
+			"355055BD6FE9265D44A4B9B1D20BCA234427",
 			[]TestPoint{
-				{"unknown-1", 0.000000},
-				{"UI-7", 0.000000},
-				{"DO-16", 0.000000},
-				{"unknown-1", 0.000000},
-				{"UO-7", 0.000000},
-				{"UVP-33", 0.000000},
-				{"DVP-1", 0.000000},
-				{"movement-21", 1.000000},
-				{"DI-10", 0.000000},
-				{"unknown-27", 0.000000},
-				{"unknown-1", 0.000000},
-				{"uint_16-8", 0.000000},
-				{"uint_16-9", 0.000000},
-				{"uint_16-10", 0.000000},
-			},
-			[]*model.DeviceMetaTag{},
-		},
-		{"RubixTwo",
-			"5CC08E7B3F48B2EC9F8BCD7C0B086593E2627266DC4AB1406448C223128DCBCC87B2AF3AEA5661B9D059AD2D5D8948CF782EAF8AD00EA2BE4928",
-			[]TestPoint{
-				{"unknown-1", 0.000000},
-				{"UI-7", 0.000000},
-				{"DO-16", 0.000000},
-				{"UO-1", 0.000000},
-				{"UO-7", 0.000000},
-				{"UVP-33", 0.000000},
-				{"DVP-1", 5.600000},
-				{"DI-25", 1.000000},
-				{"UVP-1", 0.000000},
-				{"unknown-1", 0.000000},
-				{"UI-25", 0.000000},
-				{"unknown-1", 0.000000},
-				{"UO-3", 0.000000},
-				{"unknown-1", 0.000000},
-				{"uint_16-10", 0.000000},
+				{"temperature", 21.830000},
+				{"pressure", 1023.700000},
+				{"humidity", 56.000000},
+				{"voltage", 4.480000},
+				{"light", 2.000000},
+				{"motion", 0.000000},
 			},
 			[]*model.DeviceMetaTag{},
 		},
 	}
 
-	runEncryptedRubixTests(tests, mockDevice, t)
+	runDispatchTests(tests, mockDevice, t)
 }
 
 // TestEncryptedZHTPayload replays real encrypted LoRaRAW frames captured from
@@ -383,7 +356,350 @@ func TestEncryptedZHTPayload(t *testing.T) {
 			},
 			MetaTags: []*model.DeviceMetaTag{},
 		},
+		// Real encrypted ZHT frame captured from production logs on 2026-05-14.
+		// Verifies the auto-detect "frame longer than plaintext" path:
+		// handleSerialPayload should pick the CMAC-verified decrypt branch and
+		// produce the same point values the live pipeline published over MQTT.
+		{
+			Name: "ZHT-Encrypted-AutoDetect",
+			Data: "00C032AA34B3C68E97813072CE3987B7BEB8C49B21054F6CF1DEAADDBF086DCE5560AA400442F4616745251129C3920C4002C373FF83C3E6F2BE10A4B8C37E87193A374F369E283F5627",
+			Values: []TestPoint{
+				{"rebooted", 0}, {"sleep_mode_status", 1},
+				{"temperature_ntc_boiling", 97.5}, {"temperature_ntc_chilled", 8.2},
+				{"temperature_ntc_stream", 61.5}, {"temperature_ntc_condensor", 30.4},
+				{"fault_1", 255}, {"fault_2", 255}, {"fault_3", 255}, {"fault_4", 255},
+				{"usage_energy_kwh", 4625.5},
+				{"usage_water_delta_dispenses_boiling", 0}, {"usage_water_delta_dispenses_chilled", 0}, {"usage_water_delta_dispenses_sparkling", 0},
+				{"usage_water_delta_litres_boiling", 0}, {"usage_water_delta_litres_chilled", 0}, {"usage_water_delta_litres_sparkling", 0},
+				{"filter_warning_internal", 0}, {"filter_warning_external", 0},
+				{"filter_info_usage_litres_internal", 793}, {"filter_info_usage_days_internal", 181},
+				{"filter_info_usage_litres_external", 0}, {"filter_info_usage_days_external", 0},
+				{"filter_info_usage_litres_uv", 0}, {"filter_info_usage_days_uv", 0},
+				{"filter_warning_uv", 0}, {"co2_low_gas_warning", 0},
+				{"co2_usage_grams", 0}, {"co2_usage_days", 0},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
 	}
 
-	runEncryptedZHTTests(tests, mockDevice, t)
+	runDispatchTests(tests, mockDevice, t)
+}
+
+// TestEncryptedRubixPayload ...
+func TestEncryptedRubixPayload(t *testing.T) {
+	test = t
+	addr := "5CC08E7B"
+	mockDevice := &model.Device{
+		Name: "Rubix",
+		CommonDevice: model.CommonDevice{
+			Model:       "Rubix",
+			AddressUUID: &addr,
+		},
+	}
+
+	tests := []TestStruct{
+		{"RubixOne",
+			"5CC08E7B0547C75CF319679F441CE5E245791166007507AD486373E723865A51C914B42EDC256D94120EBA8CAE0C26BC7B23CBC57ADE51C34A26",
+			[]TestPoint{
+				{"unknown-1", 0.000000},
+				{"UI-7", 0.000000},
+				{"DO-16", 0.000000},
+				{"unknown-1", 0.000000},
+				{"UO-7", 0.000000},
+				{"UVP-33", 0.000000},
+				{"DVP-1", 0.000000},
+				{"movement-21", 1.000000},
+				{"DI-10", 0.000000},
+				{"unknown-27", 0.000000},
+				{"unknown-1", 0.000000},
+				{"uint_16-8", 0.000000},
+				{"uint_16-9", 0.000000},
+				{"uint_16-10", 0.000000},
+			},
+			[]*model.DeviceMetaTag{},
+		},
+		{"RubixTwo",
+			"5CC08E7B3F48B2EC9F8BCD7C0B086593E2627266DC4AB1406448C223128DCBCC87B2AF3AEA5661B9D059AD2D5D8948CF782EAF8AD00EA2BE4928",
+			[]TestPoint{
+				{"unknown-1", 0.000000},
+				{"UI-7", 0.000000},
+				{"DO-16", 0.000000},
+				{"UO-1", 0.000000},
+				{"UO-7", 0.000000},
+				{"UVP-33", 0.000000},
+				{"DVP-1", 5.600000},
+				{"DI-25", 1.000000},
+				{"UVP-1", 0.000000},
+				{"unknown-1", 0.000000},
+				{"UI-25", 0.000000},
+				{"unknown-1", 0.000000},
+				{"UO-3", 0.000000},
+				{"unknown-1", 0.000000},
+				{"uint_16-10", 0.000000},
+			},
+			[]*model.DeviceMetaTag{},
+		},
+	}
+
+	runDispatchTests(tests, mockDevice, t)
+}
+
+// TestEncryptedUARTPayload replays real encrypted LoRaRAW frames captured
+// from a UART device (address C3C0A660, dev_333842e4715b479e, name "AC3")
+// on 2026-05-14. Verifies the auto-detect encrypted path end-to-end:
+//
+//	handleSerialPayload sees devDesc.IsLoRaRAW == true, isUnencryptedLoRaRAW
+//	is false (frame is longer than the plaintext layout), so it calls
+//	decryptLoRaRAWPkt + buildUnencryptedRawFrame and forwards to the codec.
+//
+// Expected values are taken directly from the MQTT `module-core-loraraw/value`
+// publish in the production logs.
+func TestEncryptedUARTPayload(t *testing.T) {
+	test = t
+	addr := "C3C0A660"
+	mockDevice := &model.Device{
+		Name: "AC3",
+		CommonDevice: model.CommonDevice{
+			Model:       schema.DeviceModelUART,
+			AddressUUID: &addr,
+		},
+	}
+
+	tests := []TestStruct{
+		// Full 30-point uplink (decodedLen=88 in the logs). The two captures
+		// differ only in nonce/CMAC; both decode to the same point values.
+		{
+			Name: "UART-Encrypted-Full-1",
+			Data: "C3C0A660F96AD89881DA2DC39D83CFDEFA2174E8B5FBB30D6F920AD8943E394DFF5E79763D2F42D61BEF3A4BDAB28BA3241D6A2A61CB7ED85F32788A2C619C23A9CC4A609E93DB8428BB38AC1C46F8845438F7555D1022023226",
+			Values: []TestPoint{
+				{"UVP-1", 1}, {"UVP-2", 0}, {"UVP-3", 1},
+				{"UVP-10", 1}, {"UVP-11", 1}, {"UVP-12", 1}, {"UVP-13", 1},
+				{"UVP-14", 1}, {"UVP-15", 1}, {"UVP-16", 1}, {"UVP-17", 1},
+				{"UVP-18", 1}, {"UVP-19", 1}, {"UVP-20", 4}, {"UVP-21", 1},
+				{"UVP-30", 5}, {"UVP-31", 1},
+				{"UVP-40", 1}, {"UVP-41", 1}, {"UVP-42", 26}, {"UVP-43", 8},
+				{"UVP-44", 1}, {"UVP-45", 1},
+				{"UVP-54", 3}, {"UVP-55", 0}, {"UVP-56", 26},
+				{"UVP-57", 0}, {"UVP-59", 0},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+		{
+			Name: "UART-Encrypted-Full-2",
+			Data: "C3C0A660C0EEEBFDFC8D2AB57D42481080684F6F8CEB758C842B0A083DA9FFDE4137A6D20AE0CF061583EB9601690DF104BB10B9CD0114DA6A670391D89FCA329D97AF0E0ED6DD46F7178EE679DE31E19D8417023BFED4B83127",
+			Values: []TestPoint{
+				{"UVP-1", 1}, {"UVP-2", 0}, {"UVP-3", 1},
+				{"UVP-10", 1}, {"UVP-11", 1}, {"UVP-12", 1}, {"UVP-13", 1},
+				{"UVP-14", 1}, {"UVP-15", 1}, {"UVP-16", 1}, {"UVP-17", 1},
+				{"UVP-18", 1}, {"UVP-19", 1}, {"UVP-20", 4}, {"UVP-21", 1},
+				{"UVP-30", 5}, {"UVP-31", 1},
+				{"UVP-40", 1}, {"UVP-41", 1}, {"UVP-42", 26}, {"UVP-43", 8},
+				{"UVP-44", 1}, {"UVP-45", 1},
+				{"UVP-54", 3}, {"UVP-55", 0}, {"UVP-56", 26},
+				{"UVP-57", 0}, {"UVP-59", 0},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+		// Short response uplink (decodedLen=24 in the logs). The codec emits
+		// no UVP points for this frame; the live pipeline only publishes
+		// rssi/snr. Asserting an empty Values map proves the decryption +
+		// dispatch path doesn't error out and doesn't fabricate points.
+		{
+			Name:     "UART-Encrypted-Response",
+			Data:     "C3C0A66062CAF12AF46A435170DDE74446D38293C4CE47B33226",
+			Values:   []TestPoint{},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+	}
+
+	runDispatchTests(tests, mockDevice, t)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unencrypted (plaintext) fixtures follow.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestUnencryptedTHLPayload replays a real PLAINTEXT (unencrypted) LEGACY
+// frame captured on 2026-05-15 from a THL device "dr3" at address 3DB20FF3
+// (dev_dcf24b293849476d). The dispatcher should:
+//
+//  1. Find the device on the initial lookup (address matches the mock).
+//  2. Skip tryLegacyDecrypt entirely (initial lookup hit).
+//  3. See devDesc.IsLoRaRAW == false and take the legacy plaintext handler
+//     path — no decryption, no LoRaRAW header stripping; the codec consumes
+//     the full wire frame.
+//
+// THL is a stripped-down Droplet variant: it emits temperature/pressure/
+// humidity/voltage/light but NOT motion (5 sensor points instead of 6).
+// Expected values are taken verbatim from the live MQTT publish:
+//
+//	topic=module-core-loraraw/value device=dr3 points=7
+//	(5 sensor points + rssi + snr; only the 5 sensor points are asserted)
+func TestUnencryptedTHLPayload(t *testing.T) {
+	test = t
+
+	// dr3 @ 3DB20FF3 (dev_dcf24b293849476d)
+	addrDr3 := "3DB20FF3"
+	mockDr3 := &model.Device{
+		Name: "dr3",
+		CommonDevice: model.CommonDevice{
+			Model:       "THL",
+			AddressUUID: &addrDr3,
+		},
+	}
+	runDispatchTests([]TestStruct{
+		{
+			Name: "THL-Plaintext-dr3",
+			Data: "3DB20FF3400868262B0000D9D101B3E43400",
+			Values: []TestPoint{
+				{"temperature", 21.12},
+				{"pressure", 983.2},
+				{"humidity", 43},
+				{"voltage", 4.34},
+				{"light", 0},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+	}, mockDr3, t)
+
+	// Second real plaintext-legacy THL frame captured on 2026-05-15 from a
+	// DIFFERENT physical device "dr2" at address 10B2698C
+	// (dev_adf0902cf7684154). Same dispatch path as dr3 above; different
+	// address proves the codec doesn't accidentally hard-code anything to a
+	// specific device. Bound to its own mock so the initial DB lookup hits
+	// (otherwise the dispatcher would mistakenly try legacy auto-decrypt).
+	addrDr2 := "10B2698C"
+	mockDr2 := &model.Device{
+		Name: "dr2",
+		CommonDevice: model.CommonDevice{
+			Model:       "THL",
+			AddressUUID: &addrDr2,
+		},
+	}
+	runDispatchTests([]TestStruct{
+		{
+			Name: "THL-Plaintext-dr2",
+			Data: "10B2698CB7076C262E0000D987B014692C00",
+			Values: []TestPoint{
+				{"temperature", 19.75},
+				{"pressure", 983.6},
+				{"humidity", 46},
+				{"voltage", 4.34},
+				{"light", 0},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+	}, mockDr2, t)
+}
+
+// TestUnencryptedZHTPayload replays a real PLAINTEXT (unencrypted) LoRaRAW
+// frame captured on 2026-05-15 from a ZipHydroTap with address 00C03200
+// (device zht-1, dev_4d0cd6dfec1b4485). The dispatcher should:
+//
+//  1. Find the device on the initial lookup (address matches the mock).
+//  2. Detect the frame as unencrypted LoRaRAW because its length matches the
+//     plaintext layout exactly (no AES padding, no CMAC).
+//  3. Strip the LoRaRAW header (addr+opts+nonce+len) and decode the inner
+//     payload through DecodeZHT.
+//
+// Expected values are taken verbatim from the live MQTT publish:
+//
+//	topic=module-core-loraraw/value device=zht-1 points=31
+func TestUnencryptedZHTPayload(t *testing.T) {
+	test = t
+	addr := "00C03200"
+	mockDevice := &model.Device{
+		Name: "zht-1",
+		CommonDevice: model.CommonDevice{
+			Model:       schema.DeviceModelZiptHydroTap,
+			AddressUUID: &addr,
+		},
+	}
+
+	// Two consecutive captures (sec 17 and sec 02) that differ only in the
+	// 1-byte nonce field (0x4C vs 0x4D). Both decode to the same point
+	// values — useful as a nonce-independence regression.
+	tests := []TestStruct{
+		{
+			Name: "ZHT-Plaintext-1",
+			Data: "00C03200014C28030101C5034E000D021A01FFFFFFFFD53500000000000000000000000000000002012C00000000004100",
+			Values: []TestPoint{
+				{"rebooted", 0}, {"sleep_mode_status", 1},
+				{"temperature_ntc_boiling", 96.5}, {"temperature_ntc_chilled", 7.800000190734863},
+				{"temperature_ntc_stream", 52.5}, {"temperature_ntc_condensor", 28.200000762939453},
+				{"fault_1", 255}, {"fault_2", 255}, {"fault_3", 255}, {"fault_4", 255},
+				{"usage_energy_kwh", 1378.0999755859375},
+				{"usage_water_delta_dispenses_boiling", 0}, {"usage_water_delta_dispenses_chilled", 0}, {"usage_water_delta_dispenses_sparkling", 0},
+				{"usage_water_delta_litres_boiling", 0}, {"usage_water_delta_litres_chilled", 0}, {"usage_water_delta_litres_sparkling", 0},
+				{"filter_warning_internal", 0}, {"filter_warning_external", 0},
+				{"filter_info_usage_litres_internal", 258}, {"filter_info_usage_days_internal", 44},
+				{"filter_info_usage_litres_external", 0}, {"filter_info_usage_days_external", 0},
+				{"filter_info_usage_litres_uv", 0}, {"filter_info_usage_days_uv", 0},
+				{"filter_warning_uv", 0}, {"co2_low_gas_warning", 0},
+				{"co2_usage_grams", 0}, {"co2_usage_days", 0},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+		{
+			Name: "ZHT-Plaintext-2",
+			Data: "00C03200014D28030101C5034E000D021A01FFFFFFFFD53500000000000000000000000000000002012C00000000004100",
+			Values: []TestPoint{
+				{"rebooted", 0}, {"sleep_mode_status", 1},
+				{"temperature_ntc_boiling", 96.5}, {"temperature_ntc_chilled", 7.800000190734863},
+				{"temperature_ntc_stream", 52.5}, {"temperature_ntc_condensor", 28.200000762939453},
+				{"fault_1", 255}, {"fault_2", 255}, {"fault_3", 255}, {"fault_4", 255},
+				{"usage_energy_kwh", 1378.0999755859375},
+				{"usage_water_delta_dispenses_boiling", 0}, {"usage_water_delta_dispenses_chilled", 0}, {"usage_water_delta_dispenses_sparkling", 0},
+				{"usage_water_delta_litres_boiling", 0}, {"usage_water_delta_litres_chilled", 0}, {"usage_water_delta_litres_sparkling", 0},
+				{"filter_warning_internal", 0}, {"filter_warning_external", 0},
+				{"filter_info_usage_litres_internal", 258}, {"filter_info_usage_days_internal", 44},
+				{"filter_info_usage_litres_external", 0}, {"filter_info_usage_days_external", 0},
+				{"filter_info_usage_litres_uv", 0}, {"filter_info_usage_days_uv", 0},
+				{"filter_warning_uv", 0}, {"co2_low_gas_warning", 0},
+				{"co2_usage_grams", 0}, {"co2_usage_days", 0},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+	}
+
+	runDispatchTests(tests, mockDevice, t)
+}
+
+// TestUnencryptedRubixPayload replays a real PLAINTEXT (unencrypted) LoRaRAW
+// frame captured on 2026-05-15 from a Rubix device "Dorma-1" with address
+// ACC0D08A (dev_36140a4d1e774982). Same plaintext-LoRaRAW path as
+// TestUnencryptedZHTPayload but with the Rubix codec, which decodes the
+// inner payload as a tag-length-value (TLV) stream and emits a mix of
+// bool / char / uint_32 typed points.
+//
+// Expected values are taken verbatim from the live MQTT publish:
+//
+//	topic=module-core-loraraw/value device=Dorma-1 points=14
+func TestUnencryptedRubixPayload(t *testing.T) {
+	test = t
+	addr := "ACC0D08A"
+	mockDevice := &model.Device{
+		Name: "Dorma-1",
+		CommonDevice: model.CommonDevice{
+			Model:       "Rubix",
+			AddressUUID: &addr,
+		},
+	}
+
+	tests := []TestStruct{
+		{
+			Name: "Rubix-Plaintext-Dorma-1",
+			Data: "ACC0D08A00371D01019D300A601CC04980B301A603CC089813302A685CC0D88000C0F0003000",
+			Values: []TestPoint{
+				{"char-2", 76},
+				{"bool-3", 0}, {"bool-4", 0}, {"bool-5", 0}, {"bool-6", 0},
+				{"bool-7", 0}, {"bool-8", 0}, {"bool-9", 0}, {"bool-10", 0},
+				{"bool-11", 1}, {"bool-12", 0},
+				{"uint_32-14", 197568},
+			},
+			MetaTags: []*model.DeviceMetaTag{},
+		},
+	}
+
+	runDispatchTests(tests, mockDevice, t)
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	ReIterationTime      time.Duration `yaml:"re_iteration_time"`
 	LogLevel             string        `yaml:"log_level"`
 	DefaultKey           string        `yaml:"default_key" type:"secret"`
-	EnableDecryption     bool          `yaml:"enable_decryption"`
 	WriteQueueMaxRetries int           `yaml:"write_queue_max_retries"`
 	MQTTEnable           bool          `yaml:"mqtt_enable"`
 	MQTTBroker           string        `yaml:"mqtt_broker"`
@@ -33,7 +32,6 @@ func (m *Module) DefaultConfig() *Config {
 		ReIterationTime:      5 * time.Second,
 		LogLevel:             "ERROR",
 		DefaultKey:           DefaultDeviceKey,
-		EnableDecryption:     false,
 		WriteQueueMaxRetries: 5,
 		MQTTEnable:           true,
 		MQTTBroker:           "tcp://127.0.0.1:1883",


### PR DESCRIPTION
### Summary

- Remove dependency on EnableDecryption
- **Breaking**:
    - If we have the serial port **`/data/socat/loRa1`** at the network level
    - **Min version: `driver-lora >= v1.0.1-rc.5` & `driver-lora < v2.0.0-rc.1`**
- **Note**: network without `/data/socat/loRa1` doesn't need the `lora-driver`