### PR TITLE
Add encryption-only RubixEncrypted model; drop corrupted LoRaRAW frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [v1.3.4](https://github.com/NubeIO/module-core-loraraw/tree/v1.3.4) (2026-07-27)
+
+- Add encryption-only `RubixEncrypted` model and drop corrupted LoRaRAW frames instead of decoding them as plaintext garbage points
+
 ## [v1.3.3](https://github.com/NubeIO/module-core-loraraw/tree/v1.3.3) (2026-06-29)
 
 - Fix encrypted LoRaRAW frames intermittently decoded as plaintext (CMAC-based detection)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@
 go build -o module-core-loraraw
 ```
 
+### Device models & encryption policy
+
+Encryption is verified per frame with AES-CMAC: a frame that decrypts with a
+valid CMAC is processed as encrypted. What happens when the CMAC does **not**
+verify depends on the device model:
+
+| Model                | Policy                          | Corrupted frame (CMAC fails)    | Plaintext frame                  |
+|----------------------|---------------------------------|---------------------------------|----------------------------------|
+| **RubixEncrypted**   | encryption-only                 | dropped                         | dropped                          |
+| **UART**             | encryption-only                 | dropped                         | dropped                          |
+| **Rubix**            | plaintext allowed + shape guard | dropped if block-aligned        | decodes (e.g. Dorma door nodes)  |
+| **ZipHydroTap**      | plaintext allowed + shape guard | dropped if block-aligned        | decodes                          |
+| MicroEdge / Droplet  | legacy path (no LoRaRAW crypto) | —                               | decodes                          |
+
+- **Encryption-only** (RubixEncrypted, UART): the firmware of these products always
+  encrypts, so a CMAC failure can only be corruption (e.g. a weak RF link) and
+  the frame is dropped — it is never re-interpreted as plaintext. This
+  prevents corrupted ciphertext from being decoded into garbage points
+  (`unknown-*`, out-of-range values).
+- **Shape guard** (Rubix, ZipHydroTap): a plaintext frame is accepted only when
+  it is *not* shaped like a ciphertext — i.e. its inner region is not a whole
+  number of AES blocks. A block-aligned frame that fails CMAC is treated as
+  corrupted ciphertext and dropped.
+- `RubixEncrypted` uses the same codec and wire format as `Rubix`. Optical power
+  meters previously provisioned as model `Rubix` should be re-provisioned as
+  `RubixEncrypted` to get the encryption-only guarantee.
+
 ### MQTT
 
 When `mqtt_enable: true` (default), the module connects to the broker

--- a/codec/codecDefinitions.go
+++ b/codec/codecDefinitions.go
@@ -44,6 +44,14 @@ type LoRaDeviceDescription struct {
 	EncodeRequestMessage EncodeRequestMessageFunc
 	GetPointNames        func() []string
 	IsLoRaRAW            bool
+	// AllowUnencrypted permits the plaintext LoRaRAW decode path for this
+	// model. Default false: the model is treated as encryption-only, so any
+	// frame that fails CMAC is dropped rather than re-interpreted as plaintext.
+	// This closes the corrupted-ciphertext → false-plaintext → garbage-points
+	// path for encrypting models (Rubix, UART) on weak RF links. Set true only
+	// for models with genuine unencrypted deployments (e.g. ZipHydroTap), whose
+	// decoders apply their own strict structured length validation.
+	AllowUnencrypted bool
 }
 
 var NilLoRaDeviceDescription = LoRaDeviceDescription{

--- a/codecs/codecs.go
+++ b/codecs/codecs.go
@@ -61,6 +61,12 @@ var LoRaDeviceDescriptions = []codec.LoRaDeviceDescription{
 		DecodeUplink:  legacyDecoders.DecodeZHT,
 		GetPointNames: legacyDecoders.GetZHTPointNames,
 		IsLoRaRAW:     true,
+		// ZHT has genuine unencrypted deployments; allow the plaintext path.
+		// Its strict CheckPayloadLengthZHT (packet-version × payload-type ×
+		// exact length) plus the not-encryption-shaped guard in dispatchFrame
+		// keep corrupt frames out. UART and RubixEncrypted leave this false:
+		// they are encryption-only, so a CMAC failure is always dropped.
+		AllowUnencrypted: true,
 	},
 	{
 		DeviceName:           "Rubix",
@@ -71,10 +77,36 @@ var LoRaDeviceDescriptions = []codec.LoRaDeviceDescription{
 		EncodeRequestMessage: rubixDataEncoding.EncodeRequestMessage,
 		GetPointNames:        rubixDataEncoding.GetRubixPointNames,
 		IsLoRaRAW:            true,
+		// Rubix covers mixed field populations, including genuinely plaintext
+		// devices (e.g. Dorma door nodes). Keep the plaintext path open; the
+		// not-encryption-shaped guard in dispatchFrame still rejects corrupted
+		// ciphertext. Devices known to encrypt should use the
+		// RubixEncrypted model instead, which is encryption-only.
+		AllowUnencrypted: true,
 	},
 	{
+		// Encryption-only: UART firmware always encrypts (AES-CBC + CMAC), so
+		// any frame that fails CMAC is corruption and is dropped — never
+		// re-interpreted as plaintext.
 		DeviceName:           "UART",
 		Model:                schema.DeviceModelUART,
+		CheckLength:          rubixDataEncoding.CheckPayloadLengthRubix,
+		DecodeUplink:         rubixDataEncoding.DecodeRubixUplink,
+		DecodeResponse:       rubixDataEncoding.DecodeRubixResponse,
+		EncodeRequestMessage: rubixDataEncoding.EncodeRequestMessage,
+		GetPointNames:        rubixDataEncoding.GetRubixPointNames,
+		IsLoRaRAW:            true,
+	},
+	{
+		// Encryption-only Rubix (e.g. optical power meter). Same wire format
+		// and codec as Rubix, but for devices whose firmware always encrypts
+		// (AES-CBC + CMAC): a CMAC failure is corruption and is dropped. This
+		// is what stops weak-RF corrupted frames from being decoded as
+		// plaintext into garbage points. Encrypting devices previously
+		// provisioned as model "Rubix" should be re-provisioned as
+		// "RubixEncrypted" to get this guarantee.
+		DeviceName:           "RubixEncrypted",
+		Model:                schema.DeviceModelRubixEncrypted,
 		CheckLength:          rubixDataEncoding.CheckPayloadLengthRubix,
 		DecodeUplink:         rubixDataEncoding.DecodeRubixUplink,
 		DecodeResponse:       rubixDataEncoding.DecodeRubixResponse,

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -286,6 +286,18 @@ func (m *Module) dispatchFrame(
 		// which then decoded the raw ciphertext into garbage points. Instead we
 		// attempt decryption first and trust the CMAC: a valid CMAC is proof the
 		// frame is encrypted with this key; random plaintext cannot fake it.
+		//
+		// The plaintext fallback (case 2) is itself the residual ~1-in-256 leak:
+		// a corrupted encrypted frame fails CMAC, and if its (now garbage)
+		// length byte happens to satisfy isUnencryptedLoRaRAW, the ciphertext is
+		// decoded as plaintext into garbage points. On a weak RF link this
+		// recurs and pollutes the device with junk points. We close it two ways:
+		//   - Encryption-only models (Rubix, UART: AllowUnencrypted=false) never
+		//     take the plaintext path — any CMAC failure is dropped.
+		//   - Models that do allow plaintext (ZHT) take it only when the frame
+		//     is NOT shaped like a ciphertext (isEncryptionShaped): a frame
+		//     whose inner region is a whole number of AES blocks but fails CMAC
+		//     is a corrupted/forged ciphertext, not plaintext.
 		dataBytes := dataBytesOrig
 		keyBytes, err := m.getEncryptionKey(device)
 		if err != nil {
@@ -302,9 +314,12 @@ func (m *Module) dispatchFrame(
 				publishRawHex = strings.ToUpper(hex.EncodeToString(pub))
 			}
 			m.handleLoRaRAWDevice(device, devDesc, dataHex, decodedDataBytes, keyBytes, successFn, errorFn, metaFn, writtenSuccessFn, writtenErrorFn)
-		} else if isUnencryptedLoRaRAW(dataBytes) {
-			// 2. CMAC did not verify, but the length matches the plaintext
-			//    layout exactly → genuinely unencrypted frame.
+		} else if devDesc.AllowUnencrypted && !isEncryptionShaped(dataBytes) && isUnencryptedLoRaRAW(dataBytes) {
+			// 2. The model allows plaintext, the frame is not shaped like a
+			//    valid ciphertext (its inner region is not a whole number of AES
+			//    blocks), and its length matches the plaintext layout exactly →
+			//    genuinely unencrypted frame. Downstream model decoders (ZHT)
+			//    still apply their own length/structure validation.
 			log.Infof("dispatchFrame: genuine unencrypted LoRaRAW for address=%s", address)
 			payload := utils.StripLoRaRAWPayload(dataBytes)
 			if err := devDesc.DecodeUplink(dataHex, payload, devDesc, device,
@@ -312,9 +327,12 @@ func (m *Module) dispatchFrame(
 				log.Errorf("error decoding unencrypted LoRaRAW uplink: %v", err)
 			}
 		} else {
-			// 3. Neither verifiable-encrypted nor a valid plaintext shape →
-			//    corrupt or wrong key. Drop rather than publish garbage points.
-			log.Errorf("dispatchFrame: LoRaRAW frame not decryptable and not valid plaintext (address=%s): %s", address, derr)
+			// 3. CMAC did not verify and the frame is not accepted as plaintext:
+			//    either the model is encryption-only (Rubix, UART), or the frame
+			//    is shaped like a ciphertext (block-aligned inner → corrupted /
+			//    forged encrypted frame), or it is not a valid plaintext shape.
+			//    Drop rather than decode ciphertext into garbage points.
+			log.Errorf("dispatchFrame: LoRaRAW frame not decryptable and not accepted as plaintext (address=%s, allowUnencrypted=%v, encShaped=%v): %s", address, devDesc.AllowUnencrypted, isEncryptionShaped(dataBytes), derr)
 			return DispatchResult{}
 		}
 	} else {
@@ -522,12 +540,24 @@ func createAck(address, key []byte, nonce int) []byte {
 // attempting decryption, turning a would-be panic into a clean error so the
 // caller can fall back to the plaintext path.
 func tryDecryptLoRaRAWPkt(dataBytes []byte, byteKey []byte) ([]byte, error) {
-	// inner = bytes that get CBC-decrypted = (frame - rssi/snr) - header - cmac
-	inner := len(dataBytes) - 2 - aesutils.LoraRawHeaderLen - aesutils.LoraRawCmacLen
-	if inner <= 0 || inner%aes.BlockSize != 0 {
+	if !isEncryptionShaped(dataBytes) {
 		return nil, errors.New("not an encrypted LoRaRAW frame (inner length not block-aligned)")
 	}
 	return decryptLoRaRAWPkt(dataBytes, byteKey)
+}
+
+// isEncryptionShaped reports whether dataBytes could be a valid LoRaRAW
+// ciphertext: after stripping rssi/snr (2), the region between the plaintext
+// address header and the trailing CMAC must be a whole number of AES blocks
+// (aesutils.Decrypt's cipher.CryptBlocks requires this and would otherwise
+// panic). A frame that is encryption-shaped but fails CMAC is a corrupted or
+// wrongly-keyed ciphertext, NOT plaintext — the dispatcher uses this to refuse
+// the plaintext fallback for such frames. Genuine plaintext frames have
+// arbitrary payload lengths that are almost never block-aligned this way.
+func isEncryptionShaped(dataBytes []byte) bool {
+	// inner = bytes that get CBC-decrypted = (frame - rssi/snr) - header - cmac
+	inner := len(dataBytes) - 2 - aesutils.LoraRawHeaderLen - aesutils.LoraRawCmacLen
+	return inner > 0 && inner%aes.BlockSize == 0
 }
 
 func decryptLoRaRAWPkt(dataBytes []byte, byteKey []byte) ([]byte, error) {

--- a/pkg/app_encrypted_test.go
+++ b/pkg/app_encrypted_test.go
@@ -716,10 +716,11 @@ func TestUnencryptedZHTPayload(t *testing.T) {
 
 // TestUnencryptedRubixPayload replays a real PLAINTEXT (unencrypted) LoRaRAW
 // frame captured on 2026-05-15 from a Rubix device "Dorma-1" with address
-// ACC0D08A (dev_36140a4d1e774982). Same plaintext-LoRaRAW path as
-// TestUnencryptedZHTPayload but with the Rubix codec, which decodes the
-// inner payload as a tag-length-value (TLV) stream and emits a mix of
-// bool / char / uint_32 typed points.
+// ACC0D08A (dev_36140a4d1e774982). Rubix keeps AllowUnencrypted=true because
+// field populations like the Dorma door nodes genuinely transmit plaintext —
+// this test locks in that they continue to decode. Devices known to encrypt
+// (optical power meters) should be provisioned as model "RubixEncrypted" instead,
+// which is encryption-only (see TestPlaintextRubixEncryptedDropped).
 //
 // Expected values are taken verbatim from the live MQTT publish:
 //
@@ -730,7 +731,7 @@ func TestUnencryptedRubixPayload(t *testing.T) {
 	mockDevice := &model.Device{
 		Name: "Dorma-1",
 		CommonDevice: model.CommonDevice{
-			Model:       "Rubix",
+			Model:       schema.DeviceModelRubix,
 			AddressUUID: &addr,
 		},
 	}
@@ -751,4 +752,43 @@ func TestUnencryptedRubixPayload(t *testing.T) {
 	}
 
 	runDispatchTests(tests, mockDevice, t)
+}
+
+// TestPlaintextRubixEncryptedDropped asserts the encryption-only policy for the
+// RubixEncrypted model: optical power meter firmware always encrypts (AES-CBC +
+// CMAC), so a plaintext-layout frame arriving for a RubixEncrypted device can only
+// be corruption or misconfiguration and must be dropped, never decoded.
+// (Same frame bytes as the Dorma fixture above, which DO decode under model
+// Rubix — the model is the only difference.)
+func TestPlaintextRubixEncryptedDropped(t *testing.T) {
+	test = t
+	addr := "ACC0D08A"
+	mockDevice := &model.Device{
+		Name: "RubixEncrypted-Plaintext",
+		CommonDevice: model.CommonDevice{
+			Model:       schema.DeviceModelRubixEncrypted,
+			AddressUUID: &addr,
+		},
+	}
+	m := &Module{config: &Config{DefaultKey: testDefaultKey}}
+
+	got := map[string]float64{}
+	capture := func(name string, value float64, _ *model.Device, _ *codec.LoRaDeviceDescription) error {
+		got[name] = value
+		return nil
+	}
+
+	res := m.dispatchFrame(
+		"ACC0D08A00371D01019D300A601CC04980B301A603CC089813302A685CC0D88000C0F0003000",
+		newMockGetDevice(mockDevice, addr),
+		capture, noopPointErr, noopMetaTags,
+		noopWrittenOK, noopWrittenErr,
+	)
+
+	if res.OK {
+		t.Errorf("plaintext frame for RubixEncrypted device was accepted (OK=true); expected drop (encryption-only model)")
+	}
+	if len(got) != 0 {
+		t.Errorf("plaintext frame for RubixEncrypted device produced %d point(s), expected 0: %v", len(got), got)
+	}
 }

--- a/pkg/app_falsepositive_test.go
+++ b/pkg/app_falsepositive_test.go
@@ -1,8 +1,11 @@
 package pkg
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
+	"github.com/NubeIO/module-core-loraraw/codec"
 	"github.com/NubeIO/module-core-loraraw/schema"
 	"github.com/NubeIO/nubeio-rubix-lib-models-go/model"
 )
@@ -25,9 +28,9 @@ func TestEncryptedRubixLengthFalsePositive(t *testing.T) {
 
 	// The encrypted/plaintext classification lives in dispatchFrame's
 	// IsLoRaRAW branch, ahead of model-specific codec dispatch, so the fix is
-	// model-agnostic. Both Rubix and UART are IsLoRaRAW devices sharing the
-	// same DecodeRubixUplink decoder; assert both to lock that in.
-	models := []string{schema.DeviceModelRubix, schema.DeviceModelUART}
+	// model-agnostic. Rubix, UART and RubixEncrypted are IsLoRaRAW devices sharing
+	// the same DecodeRubixUplink decoder; assert all three to lock that in.
+	models := []string{schema.DeviceModelRubix, schema.DeviceModelUART, schema.DeviceModelRubixEncrypted}
 	for _, deviceModel := range models {
 		deviceModel := deviceModel
 		t.Run(deviceModel, func(t *testing.T) {
@@ -58,6 +61,85 @@ func TestEncryptedRubixLengthFalsePositive(t *testing.T) {
 			}
 
 			runDispatchTests(tests, mockDevice, t)
+		})
+	}
+}
+
+// TestCorruptedEncryptedRubixDropped locks in the fix for the corrupted-
+// ciphertext → false-plaintext → garbage-points leak.
+//
+// It reuses the AES-encrypted Rubix fixture from the test above, whose
+// ciphertext byte at the inner-length offset makes it satisfy the plaintext
+// length heuristic (isUnencryptedLoRaRAW). We then flip a *ciphertext* byte
+// (not the length byte at index 6, not the trailing rssi/snr) so the frame
+// still passes isUnencryptedLoRaRAW but now fails CMAC — exactly what a weak-RF
+// bit-error does to a genuine encrypted frame.
+//
+// This is the ambiguous overlap the fix resolves: the frame is BOTH
+// encryption-shaped (block-aligned inner) AND plaintext-length-valid. Because a
+// block-aligned frame that fails CMAC is a corrupted ciphertext (not
+// plaintext), dispatchFrame must DROP it (case 3) rather than decode the
+// ciphertext into garbage points. Before the fix this produced a burst of junk
+// points (unknown-*, huge values).
+//
+// Asserted for both Rubix (plaintext-allowed: the drop comes from the
+// not-encryption-shaped guard) and RubixEncrypted (encryption-only: the drop comes
+// from the model policy) — both must refuse to decode this frame.
+func TestCorruptedEncryptedRubixDropped(t *testing.T) {
+	test = t
+
+	const encryptedFixture = "65C0640DA98521CC47B800BF4F2E90E4014F5279F207180C56A29EE9604CE987A1BA825351BDEF154126"
+	b, err := hex.DecodeString(encryptedFixture)
+	if err != nil {
+		t.Fatalf("decode fixture: %s", err)
+	}
+	b[12] ^= 0xFF // corrupt a ciphertext byte → CMAC fails; length byte (idx 6) untouched
+
+	// Precondition: the corrupted frame must sit in the overlap zone — it must
+	// look like plaintext to the length heuristic AND be encryption-shaped —
+	// otherwise it would be dropped for the wrong reason and the test wouldn't
+	// exercise the leak.
+	if !isUnencryptedLoRaRAW(b) {
+		t.Fatalf("corrupted fixture no longer satisfies isUnencryptedLoRaRAW; cannot exercise the leak")
+	}
+	if !isEncryptionShaped(b) {
+		t.Fatalf("corrupted fixture is not encryption-shaped; cannot exercise the leak")
+	}
+	corrupted := strings.ToUpper(hex.EncodeToString(b))
+
+	for _, deviceModel := range []string{schema.DeviceModelRubix, schema.DeviceModelRubixEncrypted} {
+		deviceModel := deviceModel
+		t.Run(deviceModel, func(t *testing.T) {
+			test = t
+			addr := "65C0640D"
+			mockDevice := &model.Device{
+				Name: "Optical-Test",
+				CommonDevice: model.CommonDevice{
+					Model:       deviceModel,
+					AddressUUID: &addr,
+				},
+			}
+			m := &Module{config: &Config{DefaultKey: testDefaultKey}}
+
+			got := map[string]float64{}
+			capture := func(name string, value float64, _ *model.Device, _ *codec.LoRaDeviceDescription) error {
+				got[name] = value
+				return nil
+			}
+
+			res := m.dispatchFrame(
+				corrupted,
+				newMockGetDevice(mockDevice, addr),
+				capture, noopPointErr, noopMetaTags,
+				noopWrittenOK, noopWrittenErr,
+			)
+
+			if res.OK {
+				t.Errorf("corrupted encrypted %s frame was accepted (OK=true); expected drop", deviceModel)
+			}
+			if len(got) != 0 {
+				t.Errorf("corrupted encrypted %s frame produced %d point(s), expected 0 (garbage leak): %v", deviceModel, len(got), got)
+			}
 		})
 	}
 }

--- a/schema/device.go
+++ b/schema/device.go
@@ -3,14 +3,15 @@ package schema
 import "github.com/NubeIO/lib-schema-go/schema"
 
 const (
-	DeviceModelTHLM         = "THLM"
-	DeviceModelTHL          = "THL"
-	DeviceModelTH           = "TH"
-	DeviceModelMicroEdgeV1  = "MicroEdgeV1"
-	DeviceModelMicroEdgeV2  = "MicroEdgeV2"
-	DeviceModelZiptHydroTap = "ZipHydroTap"
-	DeviceModelRubix        = "Rubix"
-	DeviceModelUART         = "UART"
+	DeviceModelTHLM           = "THLM"
+	DeviceModelTHL            = "THL"
+	DeviceModelTH             = "TH"
+	DeviceModelMicroEdgeV1    = "MicroEdgeV1"
+	DeviceModelMicroEdgeV2    = "MicroEdgeV2"
+	DeviceModelZiptHydroTap   = "ZipHydroTap"
+	DeviceModelRubix          = "Rubix"
+	DeviceModelUART           = "UART"
+	DeviceModelRubixEncrypted = "RubixEncrypted"
 )
 
 type DeviceKey struct {
@@ -32,7 +33,7 @@ type DeviceSchema struct {
 }
 
 func GetDeviceSchema() *DeviceSchema {
-	models := []string{DeviceModelTHLM, DeviceModelTHL, DeviceModelTH, DeviceModelMicroEdgeV1, DeviceModelMicroEdgeV2, DeviceModelZiptHydroTap, DeviceModelRubix, DeviceModelUART}
+	models := []string{DeviceModelTHLM, DeviceModelTHL, DeviceModelTH, DeviceModelMicroEdgeV1, DeviceModelMicroEdgeV2, DeviceModelZiptHydroTap, DeviceModelRubix, DeviceModelUART, DeviceModelRubixEncrypted}
 	m := &DeviceSchema{}
 	m.AddressUUID.Min = 8
 	m.AddressUUID.Max = 8


### PR DESCRIPTION
We were seeing random points (`unknown-3`, `uint_32-13`, values like 6.9e18) being created under OP-01 devices on sites with weak LoRa signal. Turned out corrupted encrypted frames were failing CMAC and then falling through to the plaintext decoder — roughly 1 in 256 corrupted frames end up with a length byte that happens to match the plaintext layout, and the raw ciphertext gets parsed as a Rubix bitstream into garbage points. One bad frame = a burst of ~20 junk points.

We can't just make Rubix encryption-only because there are plaintext Rubix devices in the field (Dorma door nodes), so:

- New `RubixEncrypted` model. Same codec/wire format as Rubix, but encryption-only like UART: CMAC failure means the frame is corrupt, drop it. Optical power meters currently provisioned as `Rubix` should be re-provisioned to `RubixEncrypted` to get this.
- Rubix and ZipHydroTap still accept plaintext, but only when the frame isn't block-aligned like AES ciphertext (`isEncryptionShaped`). A corrupted encrypted frame keeps its block-aligned length, so it now gets dropped instead of decoded. Genuine plaintext frames (Dorma 38B, ZHT 49B) are never block-aligned, so they keep working.
- Legacy devices (MicroEdge, Droplet) untouched.

Verified against live captures from field devices: encrypted optical power meters and UART, plaintext Dorma and ZipHydroTap units — encrypted keep decoding, plaintext keep decoding, corrupted frames drop.

A couple of notes for rollout:
- This only stops new junk points — the existing ones on affected devices need manual cleanup.
- Devices on weak links will now show missing readings instead of garbage when frames corrupt. The RF link on the worst affected site still needs sorting (antenna/placement).